### PR TITLE
More accurate softlif in tensorflow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Release History
 - Improved speed of parameter fetching though ``get_nengo_params``
 - Raise a warning if user tries to train a network with non-differentiable
   elements (requires ``tensorflow>=1.9.0``)
+- Improved accuracy of ``SoftLIFRate`` implementation for small values (`#45
+  <https://github.com/nengo/nengo-dl/pull/45>`_)
 
 **Fixed**
 

--- a/nengo_dl/benchmarks.py
+++ b/nengo_dl/benchmarks.py
@@ -365,10 +365,17 @@ def build(obj, benchmark, dimensions, neurons_per_d, neuron_type,
     """Builds one of the benchmark networks"""
 
     benchmark = globals()[benchmark]
-    neuron_type = getattr(nengo, neuron_type)()
-    net = benchmark(
-        dimensions, neurons_per_d, neuron_type,
-        **dict((k, int(v)) for k, v in [a.split("=") for a in kwarg]))
+    try:
+        neuron_type = getattr(nengo, neuron_type)()
+    except AttributeError:
+        neuron_type = getattr(nengo_dl, neuron_type)()
+    kwargs = dict((k, int(v)) for k, v in [a.split("=") for a in kwarg])
+    if benchmark == mnist:
+        net = benchmark(**kwargs)
+    else:
+        net = benchmark(
+            dimensions=dimensions, neurons_per_d=neurons_per_d,
+            neuron_type=neuron_type, **kwargs)
     obj["net"] = net
 
 


### PR DESCRIPTION
This is a change that I also made in `nengo_extras` (see [here](https://github.com/nengo/nengo-extras/blob/cfc3bbc048112fe9a29bc4f6e50267aa243225ad/nengo_extras/keras.py#L44)).

Basically, for small `j`, `z = log(1 + exp(j/sigma))*sigma = sigma*exp(j/sigma)` since `log(1 + x) = x` for small `x`. Then, `log(1 + 1/z) = log((z + 1) / z) = log(1 / z)` since `z` is also small and `z + 1 = 1`. Finally, `log(1/z) = -log(z) = -log(sigma*exp(j/sigma)) = -j/sigma - log(sigma)`.