### PR TITLE
Improve efficiency of parameter fetching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Release History
 - Updated spiking MNIST example to simplify and improve performance.
 - Passing unknown configuration options to ``nengo_dl.configure_settings``
   will now give a more explicit error message.
+- Improved speed of parameter fetching though ``get_nengo_params``
 
 **Fixed**
 
@@ -51,6 +52,9 @@ Release History
 - Better error message if user tries to train a network with non-differentiable
   elements
 - Fixed some broken cross references in the documentation
+- Fixed several edge cases for ``get_nengo_params``; don't use trained gains
+  for direct neuron connections, error raised if ``get_nengo_params`` applied
+  to an Ensemble with Direct neurons
 
 **Deprecated**
 


### PR DESCRIPTION
This reworks the parameter fetching logic so that all the requested parameters are fetched in a single `sess.run` call, rather than being fetched one at a time.  This can be a significant improvement when fetching large numbers of parameters (e.g., when using `sim.freeze_params`).

There are also two bugs that were discovered/fixed during this process:

1. When optimizing encoders in NengoDL we are effectively optimizing gains and encoders at the same time (because those are rolled together into the `scaled_encoders` parameter).  However, direct neural connections bypass those encoders, meaning that they are using the original, untrained gains. So when we use `get_nengo_params` we don't want to return the trained Ensemble gains (which we were doing previously), because that will change the behaviour of any direct neural connections.  Instead we keep the gains the same, and roll the trained gains into the encoders for the decoded connections.

2. The nengo build process ignores the encoders specified on the Ensemble definition for Direct ensembles.  That means it is not possible for us to specify updated encoders through the nengo model definition (using `get_nengo_params` or `freeze_params`).  Previously this would just be silently ignored, now we explicitly raise an Exception.  Note that in practice this won't make much difference; Direct ensembles are not differentiable, so it is unlikely that we would ever need to fetch their trained encoders.