### PR TITLE
TensorFlow 1.9.0 compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,8 @@ Release History
 - Passing unknown configuration options to ``nengo_dl.configure_settings``
   will now give a more explicit error message.
 - Improved speed of parameter fetching though ``get_nengo_params``
+- Raise a warning if user tries to train a network with non-differentiable
+  elements (requires ``tensorflow>=1.9.0``)
 
 **Fixed**
 
@@ -49,8 +51,6 @@ Release History
   `#41 <https://github.com/nengo/nengo-dl/issues/41>`_)
 - Fixed node outputs changing after simulator is built (fixes `#4
   <https://github.com/nengo/nengo-dl/issues/4>`__)
-- Better error message if user tries to train a network with non-differentiable
-  elements
 - Fixed some broken cross references in the documentation
 - Fixed several edge cases for ``get_nengo_params``; don't use trained gains
   for direct neuron connections, error raised if ``get_nengo_params`` applied

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,7 @@ Release History
 - Fixed several edge cases for ``get_nengo_params``; don't use trained gains
   for direct neuron connections, error raised if ``get_nengo_params`` applied
   to an Ensemble with Direct neurons
+- Compatible with ``tensorflow==1.9.0`` release
 
 **Deprecated**
 

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -368,7 +368,8 @@ class TensorGraph(object):
                         # aren't accidentally creating new variables for
                         # unrolled iterations (this is really only a concern
                         # with TensorNodes)
-                        with tf.variable_scope("", reuse=iter > 0):
+                        with tf.variable_scope(tf.get_variable_scope(),
+                                               reuse=iter > 0):
                             probe_tensors, side_effects = self.build_step()
 
                     # copy probe data to array


### PR DESCRIPTION
1. Use ``tf.variable_scope(tf.get_variable_scope())`` instead of ``tf.variable_scope("")`` (see "Breaking Changes" in https://github.com/tensorflow/tensorflow/releases/tag/v1.9.0).

2. Raise a warning when training a network with non-differentiable elements, rather than an error.  This fixes an error in `whitepaper2018_code.py` that I didn't notice until TF 1.9.0 was officially released (because that code isn't tested against pre-releases).  And, in hindsight, this is a better solution, since there may be legitimate cases where a user wants to call ``sim.train`` on a network that isn't (completely) differentiable.