### PR TITLE
Add warning for 1-step training if synapse=None

### DIFF
--- a/.ci/run_checks.bat
+++ b/.ci/run_checks.bat
@@ -1,16 +1,16 @@
-set DEVICE="/gpu:0"
+set DEVICE=%1
 
-cd ..
 set DIR=%cd%
+set PYOPENCL_CTX=0
 
-pylint nengo_dl --rcfile=setup.cfg
+pylint ../nengo_dl --rcfile=../setup.cfg
 pytest --pyargs nengo --device=%DEVICE% --dtype=float32 --unroll_simulation=1 || goto :exit
-pytest --gpu --device=%DEVICE% --dtype=float32 --unroll_simulation=1 || goto :exit
-python nengo_dl/benchmarks.py performance_samples --device %DEVICE% || goto :exit
+pytest ../nengo_dl --device=%DEVICE% --dtype=float32 --unroll_simulation=1 || goto :exit
+python ../nengo_dl/benchmarks.py performance_samples --device %DEVICE% || goto :exit
 
 cd %TEMP%
-python %DIR%docs/whitepaper/whitepaper2018_plots.py --no-show --reps 1 test || goto :exit
+python %DIR%/../docs/whitepaper/whitepaper2018_plots.py --no-show --reps 1 test || goto :exit
 
 :exit
-  cd %DIR%.ci
+  cd %DIR%
   exit /b %errorlevel%

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Release History
 1.2.1 (unreleased)
 ------------------
 
+**Added**
+
+- Added a warning if users run one-timestep training with a network containing
+  synaptic filters.
+
 **Changed**
 
 - Test Simulator parameters are now controlled through pytest arguments,

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ Release History
 
 - Test Simulator parameters are now controlled through pytest arguments,
   rather than environment variables.
+- Disable INFO-level TensorFlow logging (from C side) on import.  Added a
+  NengoDL log message indicating the device the simulation will run on, as
+  a more concise replacement.
 
 **Fixed**
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+import pkg_resources
+
 import nengo.conftest
 from nengo.conftest import seed  # pylint: disable=unused-import
 from nengo.tests import test_synapses, test_learning_rules
@@ -9,8 +11,8 @@ from nengo_dl import config, simulator
 
 
 def pytest_runtest_setup(item):
-    if getattr(item.obj, "gpu", False) and not item.config.getvalue("--gpu"):
-        pytest.skip("GPU tests not requested")
+    if getattr(item.obj, "gpu", False) and not pytest.gpu_installed:
+        pytest.skip("This test requires tensorflow-gpu")
     elif (hasattr(item, "fixturenames") and
           "Simulator" not in item.fixturenames and
           item.config.getvalue("--simulator-only")):
@@ -21,8 +23,6 @@ def pytest_runtest_setup(item):
 
 
 def pytest_addoption(parser):
-    parser.addoption("--gpu", action="store_true", default=False,
-                     help="Run GPU tests")
     parser.addoption("--simulator-only", action="store_true", default=False,
                      help="Only run tests involving Simulator")
     parser.addoption("--inference-only", action="store_true", default=False,
@@ -34,6 +34,12 @@ def pytest_addoption(parser):
                      help="unroll_simulation value for Simulator")
     parser.addoption("--device", default=None,
                      help="device parameter for Simulator")
+
+
+def pytest_namespace():
+    installed_dists = [d.project_name for d in pkg_resources.working_set]
+    return {"gpu_installed": ("tensorflow-gpu" in installed_dists or
+                              "tf-nightly-gpu" in installed_dists)}
 
 
 @pytest.fixture(scope="session")

--- a/nengo_dl/__init__.py
+++ b/nengo_dl/__init__.py
@@ -19,6 +19,11 @@ tensorflow_patch.patch_dynamic_stitch_grad()
 tensorflow_patch.patch_state_grads()
 
 # filter out "INFO" level log messages
-import tensorflow as tf  # pylint: disable=wrong-import-order,wrong-import-position
+# pylint: disable=wrong-import-order,wrong-import-position
+import os
+import tensorflow as tf
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"
 tf.logging.set_verbosity(tf.logging.WARN)
-del tf  # we don't want a nengo_dl.tf attribute
+# we don't want a nengo_dl.tf/os attribute
+del os
+del tf

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -117,15 +117,16 @@ class Simulator(object):
 
         # TODO: multi-GPU support
 
-        if device is None:
-            # check GPU support
-            installed_dists = [d.project_name for d in
-                               pkg_resources.working_set]
-            if ("tensorflow-gpu" not in installed_dists and
-                    "tf-nightly-gpu" not in installed_dists):
-                warnings.warn(
-                    "No GPU support detected. It is recommended that you "
-                    "install tensorflow-gpu (`pip install tensorflow-gpu`).")
+        installed_dists = [d.project_name for d in pkg_resources.working_set]
+        if device is None and ("tensorflow-gpu" not in installed_dists and
+                               "tf-nightly-gpu" not in installed_dists):
+            warnings.warn(
+                "No GPU support detected. It is recommended that you "
+                "install tensorflow-gpu (`pip install tensorflow-gpu`).")
+            logger.info("Running on CPU")
+        else:
+            logger.info("Running on %s", "CPU/GPU" if device is None else (
+                "CPU" if "cpu" in device else "GPU"))
 
         ProgressBar = (utils.ProgressBar if progress_bar else
                        utils.NullProgressBar)

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -500,6 +500,14 @@ class Simulator(object):
             raise ValidationError(
                 "Network was created with inference_only=True, cannot "
                 "be trained", "inference_only")
+        if (n_steps == 1 and self.model.toplevel is not None and
+                any(x.synapse is not None for x in
+                    (self.model.toplevel.all_connections +
+                     list(targets.keys())))):
+            warnings.warn(
+                "Training for one timestep, but the network contains "
+                "synaptic filters (which will introduce at least a "
+                "one-timestep delay); did you mean to set synapse=None?")
 
         # check for non-differentiable elements in graph
         # utils.find_non_differentiable(

--- a/nengo_dl/tests/test_benchmarks.py
+++ b/nengo_dl/tests/test_benchmarks.py
@@ -3,6 +3,7 @@ import sys
 
 import pytest
 import nengo
+import tensorflow as tf
 
 from nengo_dl import benchmarks, SoftLIFRate
 
@@ -93,10 +94,15 @@ def _test_random(net, dimensions, neurons_per_d, neuron_type, n_ensembles,
 
 
 @pytest.mark.parametrize("train", (True, False))
-def test_run_profile(train):
+def test_run_profile(train, pytestconfig):
     net = benchmarks.integrator(3, 2, nengo.RectifiedLinear())
 
-    benchmarks.run_profile(net, train=train, n_steps=10, do_profile=False)
+    benchmarks.run_profile(
+        net, train=train, n_steps=10, do_profile=False,
+        device=pytestconfig.getvalue("--device"),
+        unroll_simulation=pytest.config.getvalue("--unroll_simulation"),
+        dtype=(tf.float32 if pytest.config.getvalue("dtype") == "float32" else
+               tf.float64))
 
     assert net.config[net].inference_only == (False if train else True)
 

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -494,8 +494,8 @@ def test_model_passing(Simulator, seed):
 
 @pytest.mark.parametrize("device", ["/cpu:0", "/gpu:0", None])
 def test_devices(Simulator, device, seed, caplog, pytestconfig):
-    if device == "/gpu:0" and not pytestconfig.getoption("--gpu"):
-        pytest.skip()
+    if device == "/gpu:0" and not pytest.gpu_installed:
+        pytest.skip("This test requires tensorflow-gpu")
 
     caplog.set_level(logging.INFO)
 
@@ -517,7 +517,7 @@ def test_devices(Simulator, device, seed, caplog, pytestconfig):
             assert "Running on CPU" in caplog.text
         elif device == "/gpu:0":
             assert "Running on GPU" in caplog.text
-        elif pytest.config.getoption("--gpu"):
+        elif pytest.gpu_installed:
             assert "Running on CPU/GPU" in caplog.text
         else:
             # device is None but gpu not installed


### PR DESCRIPTION
Synapses introduce a one-timestep delay, so it is almost certainly a mistake to be training a network for one timestep with non-`None` synapses.  This adds a warning to help users diagnose this issue (otherwise users just end up with poor training performance, which is hard to figure out).

Addresses #54 
