### PR TITLE
Update documentation build

### DIFF
--- a/.ci/run_checks.bat
+++ b/.ci/run_checks.bat
@@ -1,16 +1,15 @@
 set DEVICE=%1
-
 set DIR=%cd%
 set PYOPENCL_CTX=0
 
-pylint ../nengo_dl --rcfile=../setup.cfg
-pytest --pyargs nengo --device=%DEVICE% --dtype=float32 --unroll_simulation=1 || goto :exit
-pytest ../nengo_dl --device=%DEVICE% --dtype=float32 --unroll_simulation=1 || goto :exit
-python ../nengo_dl/benchmarks.py performance_samples --device %DEVICE% || goto :exit
+pylint ../nengo_dl --rcfile=../setup.cfg > ../tmp/run_checks.txt 2>&1 || goto :exit
+pytest --pyargs nengo --device=%DEVICE% --dtype=float32 --unroll_simulation=1 >> ../tmp/run_checks.txt 2>&1 || goto :exit
+pytest ../nengo_dl --device=%DEVICE% --dtype=float32 --unroll_simulation=1 >> ../tmp/run_checks.txt 2>&1 || goto :exit
+python ../nengo_dl/benchmarks.py performance_samples --device %DEVICE% >> ../tmp/run_checks.txt 2>&1 || goto :exit
 
-cd %TEMP%
-python %DIR%/../docs/whitepaper/whitepaper2018_plots.py --no-show --reps 1 test || goto :exit
+cd /d %TEMP%
+python %DIR%/../docs/whitepaper/whitepaper2018_plots.py --no-show --reps 1 test >> ../tmp/run_checks.txt 2>&1 || goto :exit
 
 :exit
-  cd %DIR%
+  cd /d %DIR%
   exit /b %errorlevel%

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -59,7 +59,7 @@ To run the unit tests, NengoDL uses:
 * `codespell <https://github.com/codespell-project/codespell>`_ - Used under
   `GPL license <https://github.com/codespell-project/codespell/blob/master/COPYING>`__
 * `Coverage.py <https://coverage.readthedocs.io/en/latest/>`_ - Used under
-  `Apache license <https://bitbucket.org/ned/coveragepy/src/default/NOTICE.txt?fileviewer=file-view-default>`__
+  `Apache license <https://github.com/nedbat/coveragepy/blob/master/LICENSE.txt>`__
 * `matplotlib <https://matplotlib.org/>`_ - Used under
   `modified PSF license <https://matplotlib.org/users/license.html>`__
 * `nbval <https://github.com/computationalmodelling/nbval>`_ - Used under

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -12,6 +12,7 @@ from nengo.config import ConfigError
 from nengo.ensemble import Neurons
 from nengo.exceptions import SimulationError
 from nengo.neurons import Direct
+from nengo.utils.magic import decorator
 import numpy as np
 import tensorflow as tf
 
@@ -21,15 +22,13 @@ from nengo_dl import (builder, graph_optimizer, signals, utils, tensor_node,
 logger = logging.getLogger(__name__)
 
 
-def with_self(func):
+@decorator
+def with_self(wrapped, instance, args, kwargs):
     """A decorator that can be used to ensure that any ops created within the
     wrapped method will be added to the TensorGraph object's graph."""
 
-    def func_with_self(self, *args, **kwargs):
-        with self.graph.as_default(), self.graph.device(self.device):
-            return func(self, *args, **kwargs)
-
-    return func_with_self
+    with instance.graph.as_default(), instance.graph.device(instance.device):
+        return wrapped(*args, **kwargs)
 
 
 class TensorGraph(object):

--- a/nengo_dl/tests/test_tensor_graph.py
+++ b/nengo_dl/tests/test_tensor_graph.py
@@ -371,7 +371,7 @@ def test_create_signals_partition():
     assert graph.signals[sigs[1]].key != graph.signals[sigs[2]].key
     assert graph.signals[sigs[2]].key == graph.signals[sigs[3]].key
 
-    # check that signals are partioned for different read blocks
+    # check that signals are partitioned for different read blocks
     plan = [tuple(dummies.Op(reads=[sigs[i], sigs[2 + i]]) for i in range(2))]
     graph = dummies.TensorGraph(plan, tf.float32, 10)
     graph.create_signals(sigs)
@@ -379,7 +379,7 @@ def test_create_signals_partition():
     assert graph.signals[sigs[1]].key != graph.signals[sigs[2]].key
     assert graph.signals[sigs[2]].key == graph.signals[sigs[3]].key
 
-    # check that signals are partioned for different sig types
+    # check that signals are partitioned for different sig types
     plan = [tuple(dummies.Op(reads=[sigs[i]], sets=[sigs[2 + i]])
                   for i in range(2))]
     graph = dummies.TensorGraph(plan, tf.float32, 10)

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,3 +65,5 @@ disable =
     unsupported-assignment-operation,
     unused-argument,
     useless-object-inheritance,
+known-third-party =
+    nengo

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ docs_require = [
     "numpydoc>=0.6.0",
     "Pillow>=4.1.1",
     "sphinx>=1.8.0",
-    "sphinx_rtd_theme>=0.1.9",
+    "sphinx_rtd_theme>=0.4.2",
 ]
 tests_require = [
     "click>=6.7",


### PR DESCRIPTION
Update some old links/typos, ensure decorated functions build properly, add `nengo` to `known-third-party`, and increase the minimum `sphinx_rtd_theme` version (for compatibility with sphinx 1.8.0).

Fixes #59 
