### PR TITLE
Allow TensorNode to run in Nengo GUI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ Release History
 - Fixed an error that was thrown when calling ``get_tensor`` on a ``Signal``
   that was first initialized inside the Simulation while loop
   (`#56 <https://github.com/nengo/nengo-dl/issues/56>`_)
+- Allow TensorNodes to run in Nengo GUI.
 
 1.2.0 (September 5, 2018)
 -------------------------

--- a/nengo_dl/tensor_node.py
+++ b/nengo_dl/tensor_node.py
@@ -1,7 +1,7 @@
 from nengo import Node, Connection, Ensemble, builder
 from nengo.base import NengoObject
 from nengo.builder.operator import Reset
-from nengo.exceptions import ValidationError, BuildError
+from nengo.exceptions import ValidationError, SimulationError
 from nengo.neurons import NeuronType
 from nengo.params import Default, IntParam, Parameter
 import numpy as np
@@ -133,10 +133,13 @@ class TensorNode(Node):
 
     @property
     def output(self):
-        raise BuildError(
-            "TensorNode does not have an `output` attribute (this probably "
-            "means you are trying to use a TensorNode inside a Simulator "
-            "other than Nengo DL)")
+        def output_func(*_):
+            raise SimulationError(
+                "Cannot call TensorNode output function (this probably means "
+                "you are trying to use a TensorNode inside a Simulator other "
+                "than NengoDL)")
+
+        return output_func
 
 
 @NengoBuilder.register(TensorNode)

--- a/nengo_dl/tests/test_tensor_node.py
+++ b/nengo_dl/tests/test_tensor_node.py
@@ -1,5 +1,5 @@
 import nengo
-from nengo.exceptions import ValidationError, BuildError
+from nengo.exceptions import ValidationError, SimulationError
 import numpy as np
 import pytest
 import tensorflow as tf
@@ -37,9 +37,11 @@ def test_validation(Simulator):
         n = TensorNode(lambda t: tf.zeros((5, 2)))
         assert n.size_out == 2
 
-    # can't build tensornode in regular Nengo simulator
-    with pytest.raises(BuildError):
-        nengo.Simulator(net)
+    # can't run tensornode in regular Nengo simulator
+    with nengo.Simulator(net) as sim:
+        with pytest.raises(SimulationError):
+            sim.step()
+
 
     # these tensornodes won't be validated at creation, because size_out
     # is specified. instead the validation occurs when the network is built


### PR DESCRIPTION
The GUI checks the node's `output` attribute (even though that isn't used in NengoDL).  This change allows TensorNodes to pass that check, and then NengoDL can take over the simulation.

Note that sliders still won't work (this would require some changes to Nengo GUI, to allow it to insert values into TensorFlow).  But the value plots work, so you can see what's coming out of a TensorNode.