### PR TITLE
Avoid TensorFlow 1.11.0 infinite loop bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - MODE="test"
     - PYTHON_VERSION="3.6"
     - NUMPY_VERSION="numpy<=1.14.5"  # TODO: remove restriction once TensorFlow is compatible with >1.14.5
-    - TF_VERSION="tensorflow==1.10.0"  # TODO: test on 1.11 once travis-ci hanging issues are resolved
+    - TF_VERSION="tensorflow"
     - NENGO_VERSION="nengo"
     - TEST_ARGS=""
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Release History
   that this doesn't prevent this from occurring in user models, as we cannot
   control the model structure there. If your model hangs indefinitely when
   you call ``sim.train``, try downgrading to TensorFlow 1.10.0.
+- Ensure that ``sim.training_step`` is always updated after the optimization
+  step (in certain race conditions it would sometimes update part-way through
+  the optimization step).
 
 1.2.0 (September 5, 2018)
 -------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,11 @@ Release History
   that was first initialized inside the Simulation while loop
   (`#56 <https://github.com/nengo/nengo-dl/issues/56>`_)
 - Allow TensorNodes to run in Nengo GUI.
+- Avoid bug in TensorFlow 1.11.0 that prevents certain models from
+  running (see https://github.com/tensorflow/tensorflow/issues/23383). Note
+  that this doesn't prevent this from occurring in user models, as we cannot
+  control the model structure there. If your model hangs indefinitely when
+  you call ``sim.train``, try downgrading to TensorFlow 1.10.0.
 
 1.2.0 (September 5, 2018)
 -------------------------

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -528,8 +528,8 @@ class Simulator(object):
         if opt_slots_init is not None:
             self.sess.run(opt_slots_init)
 
-        # increment training step
-        fetches.append(self.tensor_graph.training_step_inc)
+        # get training step
+        fetches.append(self.tensor_graph.training_step)
 
         # get loss op
         loss = self.tensor_graph.build_loss(objective)
@@ -582,6 +582,9 @@ class Simulator(object):
                     outputs = self.sess.run(
                         fetches, feed_dict=feed,
                         options=run_options, run_metadata=run_metadata)
+
+                    # increment training step
+                    self.sess.run(self.tensor_graph.training_step_inc)
 
                     if summary_op is not None:
                         self.summary.add_summary(outputs[-1], outputs[1])

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -579,7 +579,7 @@ def test_tensorboard(Simulator, tmpdir):
             # metadata stuff
             continue
 
-        assert event.step == i - 2
+        assert event.step == i - 3
         tags = [s.tag for s in event.summary.value]
         assert len(tags) == 7
         assert "loss/loss" in tags[0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ warning-is-error = 1
 addopts = -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator --disable-warnings
 testpaths = nengo_dl/tests
 filterwarnings = always
+xfail_strict = true
 
 [coverage:run]
 source =


### PR DESCRIPTION
TensorFlow 1.11.0 (and most likely 1.12.0, as it is unlikely this will be fixed before then) has a bug that can cause the TensorFlow build process to enter an infinite loop (see https://github.com/tensorflow/tensorflow/issues/23383).  Unfortunately there is nothing we can do to fix this on the NengoDL side, we just have to avoid the situation that can trigger this bug.  A fix has been submitted on the TensorFlow side (see https://github.com/tensorflow/tensorflow/pull/23408), which hopefully will make it into the next release.

In the meantime, if you run into this in one of your models (this is most likely to manifest as a call to ``sim.train`` getting stuck at 0% progress), try downgrading to TensorFlow 1.10.0.

Also included an unrelated fix for a bug that could cause stochastic test failures due to race conditions in the training_step update (which came up while I was fixing this).

