### PR TITLE
Progress bar and global step changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,7 +3,7 @@ skip_branch_with_pr: true
 environment:
   MODE: test
   PYTHON_VERSION: C:\Miniconda35-x64  # TODO: switch back to 3.6 if it becomes available (Miniconda36 installs 3.7 for some reason)
-  NUMPY_VERSION: numpy<1.15
+  NUMPY_VERSION: numpy
   TF_VERSION: tensorflow
   NENGO_VERSION: nengo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   global:
     - MODE="test"
     - PYTHON_VERSION="3.6"
-    - NUMPY_VERSION="numpy<=1.14.5"  # TODO: remove restriction once TensorFlow is compatible with >1.14.5
+    - NUMPY_VERSION="numpy"
     - TF_VERSION="tensorflow"
     - NENGO_VERSION="nengo"
     - TEST_ARGS=""

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,7 @@ Release History
 - Added the ``sim.run_batch`` function.  This exposes all the functionality
   that the ``sim.run``/``sim.train``/``sim.loss`` functions are based on,
   allowing advanced users full control over how to run a NengoDL simulation.
+- Added option to disable progress bar in ``sim.train`` and ``sim.loss``.
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,7 @@ Release History
 
   .. code-block:: python
 
-    sim.train({my_node: x}, {my_probe: y} , ...)
+    sim.train({my_node: x}, {my_probe: y}, ...)
 
   is now equivalent to
 
@@ -83,6 +83,8 @@ Release History
   ``my_objective(outputs, targets): ...``) if no target values are required.
 - ``utils.minibatch_generator`` now accepts a single ``data`` argument rather
   than ``inputs`` and ``targets`` (see discussion in "Breaking API changes").
+- ``sim.training_step`` is now the same as
+  ``tf.train.get_or_create_global_step()``.
 
 1.2.1 (November 2, 2018)
 ------------------------

--- a/docs/examples/spa_memory.ipynb
+++ b/docs/examples/spa_memory.ipynb
@@ -211,7 +211,7 @@
     "else:\n",
     "    # download pretrained parameters\n",
     "    urlretrieve(\n",
-    "        \"https://drive.google.com/uc?export=download&id=0B6DAasV-Fri4WnZxSEszRXF1Sjg\",\n",
+    "        \"https://drive.google.com/uc?export=download&id=1duAA6-NzKM4o7NhTVGwjGp4GaKDIGO_g\",\n",
     "        \"mem_params.zip\")\n",
     "    with zipfile.ZipFile(\"mem_params.zip\") as f:\n",
     "        f.extractall()"
@@ -546,7 +546,7 @@
     "else:\n",
     "    # download pretrained parameters\n",
     "    urlretrieve(\n",
-    "        \"https://drive.google.com/uc?export=download&id=1rKhjZDZowsj_Nhvx3Ob0UA_6YRwX0aNn\",\n",
+    "        \"https://drive.google.com/uc?export=download&id=1gxFE-wvEMDQZuoZq7fYM8VQEhBKHkDfD\",\n",
     "        \"mem_binding_params.zip\")\n",
     "    with zipfile.ZipFile(\"mem_binding_params.zip\") as f:\n",
     "        f.extractall()"

--- a/docs/examples/spa_retrieval.ipynb
+++ b/docs/examples/spa_retrieval.ipynb
@@ -248,7 +248,7 @@
     "else:\n",
     "    # download pretrained parameters\n",
     "    urlretrieve(\n",
-    "        \"https://drive.google.com/uc?export=download&id=1FtCfxWMOCp8hRJVdgk0EY2aLfbMgLaXF\",\n",
+    "        \"https://drive.google.com/uc?export=download&id=1jm7EUt7P7IFMsxmoBFXX3me-NsDMw_85\",\n",
     "        \"spa_retrieval_params.zip\")\n",
     "    with zipfile.ZipFile(\"spa_retrieval_params.zip\") as f:\n",
     "        f.extractall()\n",

--- a/docs/examples/spiking_mnist.ipynb
+++ b/docs/examples/spiking_mnist.ipynb
@@ -266,7 +266,7 @@
     "else:\n",
     "    # download pretrained weights\n",
     "    urlretrieve(\n",
-    "        \"https://drive.google.com/uc?export=download&id=18ErAZh0LFRaISLHDM-dJjjnzqvYfyjo0\", \n",
+    "        \"https://drive.google.com/uc?export=download&id=1u9JyNuRxQDUcFgkRnI1qfJVFMdnGRsjI\", \n",
     "        \"mnist_params.zip\")\n",
     "    with zipfile.ZipFile(\"mnist_params.zip\") as f:\n",
     "        f.extractall()\n",

--- a/nengo_dl/signals.py
+++ b/nengo_dl/signals.py
@@ -545,7 +545,7 @@ class SignalDict(Mapping):
                 # that would increase the size a lot, so we allow the variable
                 # to be created on the CPU if necessary, and then move it to
                 # the GPU with the identity
-                # TODO: double check if this is still true in 1.9.0
+                # TODO: double check if this is still true in the future
                 with tf.device(None):
                     const_var = tf.get_variable(
                         "constant_%d" % len(self.constant_phs),

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -627,7 +627,7 @@ class Simulator(object):
         """
 
         batch_size = (self.minibatch_size if isinstance(data, int) else
-                      next(iter(data.values())).shape[1])
+                      next(iter(data.values())).shape[0])
 
         if not isinstance(objective, dict):
             raise ValidationError("Must be a dictionary mapping Probes to "

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -580,10 +580,6 @@ class Simulator(object):
                 self.summary.add_summary(extra_vals["summaries"],
                                          extra_vals["training_step"])
 
-            # increment training step
-            # TODO: find a way to run this at the right time with one call
-            self.sess.run(self.tensor_graph.training_step_inc)
-
         # run training
         with progress:
             self.run_batch(

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -167,12 +167,7 @@ class TensorGraph(object):
                                                    name="training")
 
             # variable to track training step
-            with tf.device("/cpu:0"), tf.variable_scope("misc_vars",
-                                                        reuse=False):
-                self.training_step = tf.get_variable(
-                    "training_step", dtype=tf.int64, shape=(),
-                    trainable=False, initializer=tf.constant_initializer(0))
-                self.training_step_inc = tf.assign_add(self.training_step, 1)
+            self.training_step = tf.train.get_or_create_global_step()
         else:
             self.training_step = None
 
@@ -537,7 +532,8 @@ class TensorGraph(object):
                 grads = [tf.reduce_sum(gs, axis=0) for gs in zip(*grads)]
 
             opt_op = optimizer.apply_gradients(
-                zip(grads, tf.trainable_variables()))
+                zip(grads, tf.trainable_variables()),
+                global_step=self.training_step)
 
             return opt_op, loss
 

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -633,7 +633,7 @@ def test_tensorboard(Simulator, tmpdir):
             # metadata stuff
             continue
 
-        assert event.step == i - 3
+        assert event.step == i - 2
         tags = [s.tag for s in event.summary.value]
         assert len(tags) == 7
         assert "loss/loss" in tags[0]

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -1129,12 +1129,19 @@ def test_get_nengo_params(Simulator, seed):
 
 @pytest.mark.parametrize("progress", (True, False))
 def test_progress_bar(Simulator, progress):
+    net, _, p = dummies.linear_net()
+
     # note: ideally we would capture the stdout and check that output is
     # actually being controlled. but the pytest capturing doesn't work,
     # because it's being printed in a different thread (I think). so we just
     # check that the parameter works without error
-    with Simulator(nengo.Network(), progress_bar=progress) as sim:
+    with Simulator(net, progress_bar=progress) as sim:
         sim.run_steps(10, progress_bar=progress)
+        sim.loss(10, {p: lambda x: x}, progress_bar=progress)
+
+        if not sim.tensor_graph.inference_only:
+            sim.train(10, tf.train.GradientDescentOptimizer(0),
+                      objective={p: lambda x: x}, progress_bar=progress)
 
 
 @pytest.mark.training


### PR DESCRIPTION
- Previously we were creating our own variable to track the training step; change this to use TensorFlow's [global_step](https://www.tensorflow.org/api_docs/python/tf/train/global_step) functionality
- Add option to disable progress bars in ``sim.train``/``sim.loss``, and fix a bug in ``sim.loss`` progress bar