### PR TITLE
Speed up SignalDict.op_constant

### DIFF
--- a/nengo_dl/signals.py
+++ b/nengo_dl/signals.py
@@ -581,15 +581,18 @@ class SignalDict(Mapping):
             will be a scalar if all the ops have the same parameter value, or
             an array giving the parameter value for each element in each op.
         """
+        vals = [getattr(op, attr) for op in ops]
+        if np.allclose(vals, vals[0]):
+            return tf.constant(vals[0], dtype=dtype)
 
-        val0 = getattr(ops[0], attr)
-        if np.allclose([getattr(op, attr) for op in ops], val0):
-            return tf.constant(val0, dtype=dtype)
-
-        return self.constant(
-            [np.reshape(getattr(op, attr), [1] * (ndims - 1))
-             for i, op in enumerate(ops) for _ in range(op_sizes[i])],
-            dtype=dtype)
+        assert len(op_sizes) == len(ops)
+        v = np.zeros([sum(op_sizes)] + [1] * (ndims - 1),
+                      dtype=dtype.as_numpy_dtype())
+        k = 0
+        for val, size in zip(vals, op_sizes):
+            v[k:k+size] = val
+            k += size
+        return self.constant(v, dtype=dtype)
 
     def __getitem__(self, sig):
         return self.sig_map[sig]


### PR DESCRIPTION
Rather than having a Python loop for each `op_size` that calls
`getattr` many times, just call `getattr` once for each op and
allocate Numpy memory all at once.

I tested the timing with the following script, and it makes a big difference:
```python
import nengo
import nengo_dl

n = 1000000
with nengo.Network() as model:
    a = nengo.Ensemble(n, 1, neuron_type=nengo.LIF(tau_rc=0.2))
    b = nengo.Ensemble(n, 1, neuron_type=nengo.LIF(tau_rc=0.1))

with nengo_dl.Simulator(model) as sim:
    pass
```