### PR TITLE
Install spaun benchmark through pip

### DIFF
--- a/.ci/coverage.sh
+++ b/.ci/coverage.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e -v
 
-if [[ $1 == "script" ]]; then
+if [[ $1 == "install" ]]; then
+  pip install git+https://github.com/drasmuss/spaun2.0.git
+elif [[ $1 == "script" ]]; then
   coverage run -m pytest $TEST_ARGS -v --color=yes --pyargs nengo
   coverage run -a -m pytest $TEST_ARGS -v --color=yes --durations 20 nengo_dl
   coverage report -m

--- a/.ci/docs.sh
+++ b/.ci/docs.sh
@@ -23,10 +23,10 @@ elif [[ $1 == "after_success" ]]; then
   if [[ "$TRAVIS_BRANCH" == "$TRAVIS_TAG" ]]; then
     git commit -m "Documentation for release $TRAVIS_TAG"
     git push -q "https://$GH_TOKEN@github.com/nengo/nengo-dl.git" gh-pages-release
-  elif [[ "$TRAVIS_BRANCH" == "master" ]]; then
+  elif [[ "${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}" == "master" ]]; then
     git commit -m "Last update at $(date '+%Y-%m-%d %T')"
     git push -fq "https://$GH_TOKEN@github.com/nengo/nengo-dl.git" gh-pages-release:gh-pages
-  else
+  elif [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     git commit -m "Documentation for branch $TRAVIS_BRANCH"
     git push -fq "https://$GH_TOKEN@github.com/nengo/nengo-dl.git" gh-pages-release:gh-pages-test
   fi

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -e -v
 
-if [[ $1 == "script" ]]; then
+if [[ $1 == "install" ]]; then
+  pip install git+https://github.com/drasmuss/spaun2.0.git
+elif [[ $1 == "script" ]]; then
   pytest $TEST_ARGS -v -n 2 --color=yes --pyargs nengo
   pytest $TEST_ARGS -v -n 2 --color=yes --durations 20 nengo_dl
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
   directories:
   - $HOME/miniconda
 
-sudo: required
 dist: trusty
 
 env:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Release History
 - ``sim.loss`` will now apply ``nengo_dl.objectives.mse`` to all probes in
   ``data`` if no explicit ``objective`` is given (mirroring the default
   behaviour in ``sim.train``).
+- The Spaun benchmark network will now be installed through pip rather than
+  manually cloning and importing the repo.
 
 **Fixed**
 

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,3 +1,0 @@
-code, .rst-content tt, .rst-content code {
-    white-space: pre-wrap;
-}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,6 +10,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.viewcode",
+    "nengo_sphinx_theme",
     "nengo_sphinx_theme.ext.versions",
     "numpydoc",
     "nbsphinx",
@@ -58,9 +59,6 @@ pygments_style = "friendly"
 html_theme = "nengo_sphinx_theme"
 html_title = "NengoDL documentation"
 html_static_path = ["_static"]
-html_context = {
-    "css_files": [os.path.join("_static", "custom.css")],
-}
 htmlhelp_basename = "NengoDLdoc"
 html_last_updated_fmt = ""  # default output format
 html_show_sphinx = False

--- a/nengo_dl/benchmarks.py
+++ b/nengo_dl/benchmarks.py
@@ -6,9 +6,6 @@ import inspect
 import itertools
 import os
 import random
-import subprocess
-import sys
-import tempfile
 import time
 
 import click
@@ -273,31 +270,33 @@ def spaun(dimensions):
     .. [1] Chris Eliasmith, Terrence C. Stewart, Xuan Choo, Trevor Bekolay,
        Travis DeWolf, Yichuan Tang, and Daniel Rasmussen (2012). A large-scale
        model of the functioning brain. Science, 338:1202-1205.
+
+    Notes
+    -----
+    This network needs to be installed via
+
+    .. code-block:: bash
+
+        pip install git+https://github.com/drasmuss/spaun2.0.git
     """
 
-    # spaun needs to be downloaded from https://github.com/drasmuss/spaun2.0,
-    # and manually added to python path
-    spaun_dir = os.path.join(tempfile.gettempdir(), "spaun2.0")
-    if not os.path.exists(spaun_dir):
-        subprocess.call(
-            "git clone https://github.com/drasmuss/spaun2.0 %s" % spaun_dir,
-            shell=True)
-    sys.path.append(spaun_dir)
     from _spaun.configurator import cfg
     from _spaun.vocabulator import vocab
     from _spaun.experimenter import experiment
-    from _spaun.modules.vision.data import vis_data
-    from _spaun.modules.motor.data import mtr_data
+    from _spaun.modules.stim import stim_data
+    from _spaun.modules.vision import vis_data
+    from _spaun.modules.motor import mtr_data
     from _spaun.spaun_main import Spaun
 
     vocab.sp_dim = dimensions
     cfg.mtr_arm_type = None
 
     cfg.set_seed(1)
-    experiment.initialize('A', vis_data.get_image_ind,
-                          vis_data.get_image_label,
-                          cfg.mtr_est_digit_response_time, cfg.rng)
-    vocab.initialize(experiment.num_learn_actions, cfg.rng)
+    experiment.initialize(
+        "A", stim_data.get_image_ind, stim_data.get_image_label,
+        cfg.mtr_est_digit_response_time, "", cfg.rng)
+    vocab.initialize(
+        stim_data.stim_SP_labels, experiment.num_learn_actions, cfg.rng)
     vocab.initialize_mtr_vocab(mtr_data.dimensions, mtr_data.sps)
     vocab.initialize_vis_vocab(vis_data.dimensions, vis_data.sps)
 

--- a/nengo_dl/tests/test_benchmarks.py
+++ b/nengo_dl/tests/test_benchmarks.py
@@ -54,10 +54,12 @@ def test_mnist(tensor_layer):
 
 
 def test_spaun():
+    pytest.importorskip("_spaun")
+
     dimensions = 2
 
     net = benchmarks.spaun(dimensions=dimensions)
-    assert net.mem.mem_in.size_in == dimensions
+    assert net.mem.mb1_net.output.size_in == dimensions
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Also updates the benchmark to work with the latest version of the spaun code, and fixes a bug in the documentation building (PR builds were being treated like `master` builds).