### PR TITLE
Fix tensorflow-gpu installation check

### DIFF
--- a/.templates/gpu.sh.template
+++ b/.templates/gpu.sh.template
@@ -16,20 +16,19 @@
 {% block script %}
     exe ssh abrgpu << EOF
         export PATH="/home/travis-ci/miniconda3/bin:\$PATH"
-        HW_STATUS=0
-        cd /tmp/nengo-dl-$TRAVIS_JOB_NUMBER
-        conda create -q -y -n travis-ci-$TRAVIS_JOB_NUMBER python=$PYTHON_VERSION $TF_VERSION
-        source activate travis-ci-$TRAVIS_JOB_NUMBER
-        pip install $NENGO_VERSION $NUMPY_VERSION
+        cd /tmp/nengo-dl-"$TRAVIS_JOB_NUMBER"
+        conda create -y -n travis-ci-"$TRAVIS_JOB_NUMBER" python="$TRAVIS_PYTHON_VERSION" "$TF_VERSION" "$NUMPY_VERSION"
+        source activate travis-ci-"$TRAVIS_JOB_NUMBER"
+        pip install "$NENGO_VERSION"
         pip install git+https://github.com/drasmuss/spaun2.0.git
         pip install -e .[tests]
         echo "Waiting for lock"
         (
             flock -x -w 1800 200 || exit 1
-            pytest $TEST_ARGS --pyargs nengo -v --durations 20 --color=yes --cov=nengo_dl --cov-report=xml --cov-report=term-missing || HW_STATUS=1
-            pytest $TEST_ARGS nengo_dl -v --durations 20 --color=yes --cov=nengo_dl --cov-report=xml --cov-report=term-missing --cov-append || HW_STATUS=1
+            pytest $TEST_ARGS --pyargs nengo -v --durations 20 --color=yes --cov=nengo_dl --cov-report=xml --cov-report=term-missing || exit 1
+            pytest $TEST_ARGS nengo_dl -v --durations 20 --color=yes --cov=nengo_dl --cov-report=xml --cov-report=term-missing --cov-append || exit 1
         ) 200>/var/lock/.travis-ci.exclusivelock
-        exit \$HW_STATUS
+        exit \$?
 EOF
 {% endblock %}
 

--- a/.templates/setup.py.template
+++ b/.templates/setup.py.template
@@ -4,6 +4,7 @@
 import pkg_resources
 import sys
 
+# determine which tensorflow package to require
 if "bdist_wheel" in sys.argv:
     # when building wheels we have to pick a requirement ahead of time (can't
     # check it at install time). so we'll go with tensorflow (non-gpu), since
@@ -12,10 +13,21 @@ if "bdist_wheel" in sys.argv:
 else:
     # check if one of the tensorflow packages is already installed (so that we
     # don't force tensorflow to be installed if e.g. tensorflow-gpu is already
-    # there)
-    tf_dists = ["tf-nightly-gpu", "tf-nightly", "tensorflow-gpu"]
-    installed_dists = [d.project_name for d in pkg_resources.working_set]
-    for d in tf_dists:
+    # there).
+    # as of pep517 and pip>=10.0, pip will be running this file inside an isolated
+    # environment, so we can't just look up the tensorflow version in the current
+    # environment. but the pip package will be in the isolated sys.path, so we can use
+    # that to look up the site-packages directory of the original environment.
+    target_path = os.path.join("site-packages", "pip")
+    for path in sys.path:
+        if target_path in path:
+            source_path = [path[: path.index("pip")]]
+            break
+    else:
+        # fallback if we're not in an isolated environment (i.e. pip<10.0)
+        source_path = sys.path
+    installed_dists = [d.project_name for d in pkg_resources.WorkingSet(source_path)]
+    for d in ["tf-nightly-gpu", "tf-nightly", "tensorflow-gpu"]:
         if d in installed_dists:
             tf_req = d
             break

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Release History
 2.2.1 (unreleased)
 ==================
 
+**Fixed**
+
+- Fixed ``tensorflow-gpu`` installation check in pep517-style isolated build
+  environments.
 
 2.2.0 (July 24, 2019)
 =====================

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ version = runpy.run_path(os.path.join(root, "nengo_dl", "version.py"))["version"
 import pkg_resources
 import sys
 
+# determine which tensorflow package to require
 if "bdist_wheel" in sys.argv:
     # when building wheels we have to pick a requirement ahead of time (can't
     # check it at install time). so we'll go with tensorflow (non-gpu), since
@@ -40,10 +41,21 @@ if "bdist_wheel" in sys.argv:
 else:
     # check if one of the tensorflow packages is already installed (so that we
     # don't force tensorflow to be installed if e.g. tensorflow-gpu is already
-    # there)
-    tf_dists = ["tf-nightly-gpu", "tf-nightly", "tensorflow-gpu"]
-    installed_dists = [d.project_name for d in pkg_resources.working_set]
-    for d in tf_dists:
+    # there).
+    # as of pep517 and pip>=10.0, pip will be running this file inside an isolated
+    # environment, so we can't just look up the tensorflow version in the current
+    # environment. but the pip package will be in the isolated sys.path, so we can use
+    # that to look up the site-packages directory of the original environment.
+    target_path = os.path.join("site-packages", "pip")
+    for path in sys.path:
+        if target_path in path:
+            source_path = [path[: path.index("pip")]]
+            break
+    else:
+        # fallback if we're not in an isolated environment (i.e. pip<10.0)
+        source_path = sys.path
+    installed_dists = [d.project_name for d in pkg_resources.WorkingSet(source_path)]
+    for d in ["tf-nightly-gpu", "tf-nightly", "tensorflow-gpu"]:
         if d in installed_dists:
             tf_req = d
             break


### PR DESCRIPTION
Adding a `pyproject.toml` switched us over into pep517-style pip installation, which means that `setup.py` gets executed within an isolated build environment. This makes it difficult to check whether or not `tensorflow` is installed, which breaks our conditional logic in `setup.py` which would attempt to look for a pre-existing `tensorflow-gpu` installation. This means that our `setup.py` was installing `tensorflow` overtop of an existing `tensorflow-gpu` installation, which breaks the GPU support.  

There are two fixes here. The first is a kind of hacky fix that attempts to find the original (non-isolated) `site-packages` directory and then look in there for `tensorflow-gpu`. It's hacky, but it preserves all the same functionality as before.

The second fix takes advantage of a change in the most recent version of TensorFlow (1.14), which allows the `tensorflow-gpu` package to be used whether or not GPU support is actually available (if it isn't available, you just end up with CPU-only tensorflow).  So we can just require `tensorflow-gpu>=1.14` in all cases, and it will always work.  This has the advantage of simplicity, but it is a slight downgrade from a user experience. 1) It won't play nicely with `tf-nightly*` packages, 2) it will force `tensorflow-gpu` to be installed even if the user has an existing `tensorflow` (non-gpu) installation.