### PR TITLE
Switch to new pytest fixtures

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,16 +5,19 @@ environment:
   PYTHON_VERSION: C:\Miniconda36-x64
   NUMPY_VERSION: numpy
   TF_VERSION: tensorflow
-  NENGO_VERSION: nengo
+  NENGO_VERSION: nengo[tests]
+  TEST_ARGS: ""
 
   matrix:
     - MODE: test # default build
-    - NENGO_VERSION: git+https://github.com/nengo/nengo.git
+      TEST_ARGS: -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator
+    - NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]
       TF_VERSION: tensorflow --pre
-    - NENGO_VERSION: nengo==2.8.0
+    - NENGO_VERSION: nengo[tests]==2.8.0
       TF_VERSION: tensorflow==1.4.0
       NUMPY_VERSION: numpy==1.14.5
       PYTHON_VERSION: C:\Miniconda35-x64
+      TEST_ARGS: -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator
 
 init:
   - set PATH=%PYTHON_VERSION%;%PYTHON_VERSION%\\Scripts;%PATH%
@@ -24,6 +27,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install "six>=1.11.0"
+  - python -m pip install pip --upgrade
   - pip install %NUMPY_VERSION% %TF_VERSION% %NENGO_VERSION%
   - pip install -e .[tests]
   - conda list -e
@@ -32,4 +36,4 @@ install:
 build: false  # Not a C# project
 
 test_script:
-  - pytest -n 2 --pyargs nengo && pytest -n 2 --durations 20 nengo_dl
+  - pytest -n 2 --pyargs nengo %TEST_ARGS% && pytest -n 2 --durations 20 nengo_dl %TEST_ARGS%

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -22,54 +22,49 @@ manifest_in:
 setup_cfg:
   pytest:
     addopts:
-      - -p nengo.tests.options
-      - --simulator nengo_dl.Simulator
-      - --ref-simulator nengo_dl.Simulator
       - --disable-warnings
     filterwarnings:
       - always
     xfail_strict: True
+    nengo_simloader: nengo_dl.tests.make_test_sim
     nengo_test_unsupported:
-      nengo/tests/test_simulator.py:test_warn_on_opensim_del:
+      tests/test_simulator.py::test_warn_on_opensim_del:
         nengo_dl raises a different (more visible) warning, see
-        tests/test_nengo_tests.py:test_warn_on_opensim_del
-      nengo/tests/test_simulator.py:test_signal_init_values:
+        tests/test_nengo_tests.py::test_warn_on_opensim_del
+      tests/test_simulator.py::test_signal_init_values:
         different method required to manually step simulator, see
-        tests/test_nengo_tests.py:test_signal_init_values
-      nengo/tests/test_simulator.py:test_entry_point:
+        tests/test_nengo_tests.py::test_signal_init_values
+      tests/test_simulator.py::test_entry_point:
         overridden so we can pass custom test simulators, see
-        tests/test_nengo_tests.py:test_entry_point
-      nengo/tests/test_simulator.py:test_simulator_progress_bars:
+        tests/test_nengo_tests.py::test_entry_point
+      tests/test_simulator.py::test_simulator_progress_bars:
         nengo_dl uses a different progress bar system, see
-        tests/test_utils.py:test_progress_bar
-      nengo/tests/test_simulator.py:test_dtype[*:
+        tests/test_utils.py::test_progress_bar
+      tests/test_simulator.py::test_dtype[*:
         nengo_dl uses a different system for signals/dtype, see
-        tests/test_nengo_tests.py:test_dtype
-      nengo/tests/test_node.py:test_args:
+        tests/test_nengo_tests.py::test_dtype
+      tests/test_node.py::test_args:
         time is passed as np.float32, not a float, see
-        tests/test_nengo_tests.py:test_args
-      nengo/tests/test_node.py:test_unconnected_node:
+        tests/test_nengo_tests.py::test_args
+      tests/test_node.py::test_unconnected_node:
         need to set `unroll_simulation` to ensure node runs the correct
         number of times, see
-        tests/test_nengo_tests.py:test_unconnected_node
-      nengo/tests/test_synapses.py:test_alpha:
-        need to set looser tolerances due to float32 implementation, see
-        tests/test_processes.py:test_alpha
-      nengo/tests/test_synapses.py:test_linearfilter:
-        need to set looser tolerances due to float32 implementation, see
-        tests/test_processes.py:test_linearfilter
-      nengo/tests/test_ensemble.py:test_gain_bias:
+        tests/test_nengo_tests.py::test_unconnected_node
+      tests/test_ensemble.py::test_gain_bias:
         use allclose instead of array_equal, see
-        tests/test_simulator.py:test_gain_bias
-      nengo/tests/test_transforms.py:test_convolution*:
-        need to set looser tolerances due to float32 implementation, see
-        tests/test_transforms.py:test_convolution
-      nengo/tests/test_transforms.py:test_sparse[False-*:
+        tests/test_nengo_tests.py::test_gain_bias
+      tests/test_transforms.py::test_sparse[False-*:
         nengo-dl doesn't raise a warning for scipy=False, see
-        tests/test_nengo_tests.py:test_sparse
-      nengo/tests/test_copy.py:test_pickle_sim[*:
+        tests/test_nengo_tests.py::test_sparse
+      tests/test_copy.py::test_pickle_sim[*:
         nengo-dl does not support pickling a Simulator, see
-        tests/test_simulator.py:test_pickle_error
+        tests/test_simulator.py::test_pickle_error
+    allclose_tolerances:
+      - tests/test_synapses.py::test_lowpass atol=5e-7
+      - tests/test_synapses.py::test_triangle atol=5e-7
+      - tests/test_synapses.py::test_alpha atol=5e-5
+      - tests/test_synapses.py::test_linearfilter atol=1e-4
+      - tests/test_transforms.py::test_convolution[* atol=1e-6
   pylint:
     known_third_party:
       - PIL
@@ -124,33 +119,35 @@ travis_yml:
   global_vars:
     NUMPY_VERSION: numpy
     TF_VERSION: tensorflow
-    NENGO_VERSION: nengo
+    NENGO_VERSION: nengo[tests]
     SCIPY_VERSION: noop
   jobs:
     - script: static
     - script: docs
     - cache: false
+      test_args: -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator
     - script: gpu
       test_args: --device /gpu:3 --performance
       env:
-        NENGO_VERSION: git+https://github.com/nengo/nengo.git
+        NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]
         TF_VERSION: tensorflow-gpu
     - script: test-coverage
       env:
-        NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo
+        NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]
         TF_VERSION: tensorflow
         SCIPY_VERSION: scipy
       dist: xenial
       python: 3.7
     - script: test-coverage
       env:
-        NENGO_VERSION: nengo==2.8.0
+        NENGO_VERSION: nengo[tests]==2.8.0
         TF_VERSION: tensorflow==1.4.0
         NUMPY_VERSION: numpy==1.14.5
+      test_args: -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator
       python: 3.5
-    - test_args: --dtype float64 --simulator-only
-    - test_args: --unroll-simulation 5 --simulator-only
-    - test_args: --inference-only --simulator-only
+    - test_args: --dtype float64 --simulator-only -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator
+    - test_args: --unroll-simulation 5 --simulator-only -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator
+    - test_args: --inference-only --simulator-only -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator
     - script: examples
   pypi_user: drasmuss
   deploy_dists:
@@ -177,7 +174,9 @@ setup_py:
     - nbval>=0.6.0
     - pylint>=1.9.2
     - pytest>=3.6.0,<4.1.0  # >=4.1.0 doesn't work with nengo tests TODO: remove this once there is a compatible nengo release
+    - pytest-allclose>=1.0.0
     - pytest-cov>=2.6.0
+    - pytest-rng>=1.0.0
     - pytest-xdist>=1.16.0,<1.28.0  # 1.28.0 requires pytest>=4.4.0 (see above)
     - six>=1.11.0  # hint for pip dependency resolution, required by nbval
   entry_points:

--- a/.templates/LICENSE.rst.template
+++ b/.templates/LICENSE.rst.template
@@ -29,7 +29,7 @@ To build the documentation, NengoDL uses:
 * `sphinx-click <https://sphinx-click.readthedocs.io/en/latest/>`_ - Used under
   `MIT license <https://github.com/click-contrib/sphinx-click/blob/master/LICENSE>`__
 
-To run the unit tests, NengoDL uses:
+To run the tests, NengoDL uses:
 
 * `Click <https://click.palletsprojects.com/en/6.x/>`_ - Used under
   `BSD license <https://click.palletsprojects.com/en/6.x/license/>`__
@@ -43,7 +43,11 @@ To run the unit tests, NengoDL uses:
   `GPL license <https://github.com/PyCQA/pylint/blob/master/COPYING>`__
 * `pytest <https://docs.pytest.org/en/latest/>`_ - Used under
   `MIT license <https://docs.pytest.org/en/latest/license.html>`__
+* `pytest-allclose <https://www.nengo.ai/pytest-allclose/>`__ Used under
+  `MIT license <https://github.com/nengo/pytest-allclose/blob/master/LICENSE.rst>`__
 * `pytest-cov <https://github.com/pytest-dev/pytest-cov>`_ - Used under
   `MIT license <https://github.com/pytest-dev/pytest-cov/blob/master/LICENSE>`__
+* `pytest-rng <https://www.nengo.ai/pytest-rng/>`__ Used under
+  `MIT license <https://github.com/nengo/pytest-rng/blob/master/LICENSE.rst>`__
 * `pytest-xdist <https://github.com/pytest-dev/pytest-xdist>`_ - Used under
   `MIT license <https://github.com/pytest-dev/pytest-xdist/blob/master/LICENSE>`__

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - BRANCH_NAME="${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}"
     - NUMPY_VERSION="numpy"
     - TF_VERSION="tensorflow"
-    - NENGO_VERSION="nengo"
+    - NENGO_VERSION="nengo[tests]"
     - SCIPY_VERSION="noop"
 
 jobs:
@@ -36,16 +36,18 @@ jobs:
         packages:
           - pandoc
   -
+    env:
+      TEST_ARGS="-p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator"
     cache: False
   -
     env:
-      NENGO_VERSION="git+https://github.com/nengo/nengo.git"
+      NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo[tests]"
       TF_VERSION="tensorflow-gpu"
       SCRIPT="gpu"
       TEST_ARGS="--device /gpu:3 --performance"
   -
     env:
-      NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo"
+      NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo[tests]"
       TF_VERSION="tensorflow"
       SCIPY_VERSION="scipy"
       SCRIPT="test-coverage"
@@ -53,20 +55,21 @@ jobs:
     python: 3.7
   -
     env:
-      NENGO_VERSION="nengo==2.8.0"
+      NENGO_VERSION="nengo[tests]==2.8.0"
       TF_VERSION="tensorflow==1.4.0"
       NUMPY_VERSION="numpy==1.14.5"
       SCRIPT="test-coverage"
+      TEST_ARGS="-p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator"
     python: 3.5
   -
     env:
-      TEST_ARGS="--dtype float64 --simulator-only"
+      TEST_ARGS="--dtype float64 --simulator-only -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator"
   -
     env:
-      TEST_ARGS="--unroll-simulation 5 --simulator-only"
+      TEST_ARGS="--unroll-simulation 5 --simulator-only -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator"
   -
     env:
-      TEST_ARGS="--inference-only --simulator-only"
+      TEST_ARGS="--inference-only --simulator-only -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator"
   -
     env:
       SCRIPT="examples"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,11 @@ Release History
 2.2.1 (unreleased)
 ==================
 
+**Changed**
+
+- Update testing framework to use new nengo pytest ecosystem (``pytest-rng``,
+  ``pytest-allclose``, and ``pytest-nengo``)
+
 **Fixed**
 
 - Fixed ``tensorflow-gpu`` installation check in pep517-style isolated build

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Release History
 
 - Update testing framework to use new nengo pytest ecosystem (``pytest-rng``,
   ``pytest-allclose``, and ``pytest-nengo``)
+- Disable TensorFlow 2.0 behaviour (e.g. control flow v2) by default.  This will be
+  re-enabled when full TensorFlow 2.0 support is added.
 
 **Fixed**
 

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -53,7 +53,7 @@ To build the documentation, NengoDL uses:
 * `sphinx-click <https://sphinx-click.readthedocs.io/en/latest/>`_ - Used under
   `MIT license <https://github.com/click-contrib/sphinx-click/blob/master/LICENSE>`__
 
-To run the unit tests, NengoDL uses:
+To run the tests, NengoDL uses:
 
 * `Click <https://click.palletsprojects.com/en/6.x/>`_ - Used under
   `BSD license <https://click.palletsprojects.com/en/6.x/license/>`__
@@ -67,7 +67,11 @@ To run the unit tests, NengoDL uses:
   `GPL license <https://github.com/PyCQA/pylint/blob/master/COPYING>`__
 * `pytest <https://docs.pytest.org/en/latest/>`_ - Used under
   `MIT license <https://docs.pytest.org/en/latest/license.html>`__
+* `pytest-allclose <https://www.nengo.ai/pytest-allclose/>`__ Used under
+  `MIT license <https://github.com/nengo/pytest-allclose/blob/master/LICENSE.rst>`__
 * `pytest-cov <https://github.com/pytest-dev/pytest-cov>`_ - Used under
   `MIT license <https://github.com/pytest-dev/pytest-cov/blob/master/LICENSE>`__
+* `pytest-rng <https://www.nengo.ai/pytest-rng/>`__ Used under
+  `MIT license <https://github.com/nengo/pytest-rng/blob/master/LICENSE.rst>`__
 * `pytest-xdist <https://github.com/pytest-dev/pytest-xdist>`_ - Used under
   `MIT license <https://github.com/pytest-dev/pytest-xdist/blob/master/LICENSE>`__

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -150,6 +150,7 @@ Utilities
 ^^^^^^^^^
 
 .. automodule:: nengo_dl.utils
+    :exclude-members: MessageBar
 
 Benchmarks
 ^^^^^^^^^^

--- a/nengo_dl/__init__.py
+++ b/nengo_dl/__init__.py
@@ -32,18 +32,21 @@ del sys
 
 # filter out "INFO" level log messages
 import os
-import tensorflow as tf
 from nengo_dl.compat import tf_compat
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "1"
 tf_compat.logging.set_verbosity(tf_compat.logging.WARN)
 
-# disable eager execution (for now, pending full TF 2.0 compatibility)
-if hasattr(tf, "executing_eagerly") and tf.executing_eagerly():
-    tf_compat.disable_eager_execution()
+
+# disable v2 behaviour (for now, pending full TF 2.0 compatibility)
+try:
+    tf_compat.disable_v2_behavior()
+except AttributeError:
+    # on a version of TensorFlow that doesn't have v2 behaviour anyway, so no problem
+    pass
+
 
 del os
-del tf
 del tf_compat
 
 # need to explicitly import these to trigger the builder registration

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -23,11 +23,6 @@ if LooseVersion(tf.__version__) < LooseVersion("2.0.0"):
 
     tf_math = tf
 
-    def tf_shape(shape):
-        """Convert ``tf.Dimension`` to int."""
-
-        return tuple(x.value for x in shape)
-
     tf_uniform = tf.random_uniform
 
     RefVariable = tf.Variable
@@ -37,11 +32,6 @@ else:
     tf_convolution = tf.nn.convolution
 
     tf_math = tf.math
-
-    def tf_shape(shape):
-        """Return shape (elements are already ints)."""
-
-        return shape
 
     tf_uniform = tf.random.uniform
 

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -8,6 +8,7 @@ dependencies.
 from distutils.version import LooseVersion
 
 import nengo
+import numpy as np
 import tensorflow as tf
 
 if LooseVersion(tf.__version__) < LooseVersion("2.0.0"):
@@ -51,6 +52,7 @@ else:
 
 
 if LooseVersion(nengo.__version__) < "3.0.0":
+    from nengo.utils.testing import allclose as signals_allclose
 
     class SimPES(nengo.builder.Operator):  # pylint: disable=abstract-method
         """Future `nengo.builder.operator.SimPES` class."""
@@ -178,12 +180,15 @@ if LooseVersion(nengo.__version__) < "3.0.0":
         """Old processes don't have any state."""
         return {}
 
+    # set seed upper bound to uint32 (instead of int32)
+    nengo.base.Process.seed.high = np.iinfo(np.uint32).max
 
 else:
     from nengo.builder.learning_rules import SimPES
     from nengo.builder.transforms import ConvInc, SparseDotInc
     from nengo.transforms import Convolution, SparseMatrix
     from nengo.synapses import LinearFilter
+    from nengo.utils.testing import signals_allclose
 
     def is_sparse(sig):
         """Check if Signal is sparse"""

--- a/nengo_dl/tensor_node.py
+++ b/nengo_dl/tensor_node.py
@@ -13,7 +13,6 @@ import numpy as np
 import tensorflow as tf
 
 from nengo_dl.builder import Builder, OpBuilder, NengoBuilder
-from nengo_dl.compat import tf_shape
 
 
 def validate_output(output, minibatch_size=None, output_d=None, dtype=None):
@@ -105,7 +104,7 @@ class TensorFuncParam(Parameter):
 
             validate_output(result)
 
-            node.size_out = tf_shape(result.get_shape())[1]
+            node.size_out = result.get_shape()[1].value
 
         return output
 

--- a/nengo_dl/tests/__init__.py
+++ b/nengo_dl/tests/__init__.py
@@ -1,1 +1,38 @@
 # pylint: disable=missing-docstring
+
+import tensorflow as tf
+
+from nengo_dl import config, simulator
+
+
+def make_test_sim(request):
+    """
+    A Simulator factory to be used in tests.
+
+    The factory allows simulator arguments to be controlled via pytest command line
+    arguments.
+
+    This is used in the ``conftest.Simulator`` fixture, or can be be passed
+    to the ``nengo_simloader`` option when running the Nengo core tests.
+    """
+
+    dtype = tf.as_dtype(request.config.getoption("--dtype"))
+    unroll = request.config.getoption("--unroll-simulation")
+    device = request.config.getoption("--device")
+    inference_only = request.config.getoption("--inference-only")
+
+    def TestSimulator(net, *args, **kwargs):
+        kwargs.setdefault("unroll_simulation", unroll)
+        kwargs.setdefault("device", device)
+
+        if net is not None and config.get_setting(net, "inference_only") is None:
+            with net:
+                config.configure_settings(inference_only=inference_only)
+
+        if net is not None and config.get_setting(net, "dtype") is None:
+            with net:
+                config.configure_settings(dtype=dtype)
+
+        return simulator.Simulator(net, *args, **kwargs)
+
+    return TestSimulator

--- a/nengo_dl/tests/test_nengo_tests.py
+++ b/nengo_dl/tests/test_nengo_tests.py
@@ -195,3 +195,21 @@ def test_sparse(use_dist, Simulator, rng, seed, monkeypatch):
         ref_sim.run(sim_time)
 
     assert np.allclose(sim.data[ap], ref_sim.data[ap])
+
+
+def test_gain_bias(Simulator):
+    N = 17
+    D = 2
+
+    gain = np.random.uniform(low=0.2, high=5, size=N)
+    bias = np.random.uniform(low=0.2, high=1, size=N)
+
+    model = nengo.Network()
+    with model:
+        a = nengo.Ensemble(N, D)
+        a.gain = gain
+        a.bias = bias
+
+    with Simulator(model) as sim:
+        assert np.allclose(gain, sim.data[a].gain)
+        assert np.allclose(bias, sim.data[a].bias)

--- a/nengo_dl/tests/test_processes.py
+++ b/nengo_dl/tests/test_processes.py
@@ -3,21 +3,13 @@
 import nengo
 from nengo.builder.processes import SimProcess
 from nengo.synapses import Alpha, LinearFilter, Triangle
-from nengo.tests.test_synapses import run_synapse, allclose
+from nengo.tests.test_synapses import run_synapse
 from nengo.utils.filter_design import ss2tf
 import numpy as np
 import pytest
 
 
-def test_alpha(Simulator, seed):
-    dt = 1e-3
-    tau = 0.03
-    num, den = [1], [tau ** 2, 2 * tau, 1]
-
-    t, x, yhat = run_synapse(Simulator, seed, Alpha(tau), dt=dt)
-    y = LinearFilter(num, den).filt(x, dt=dt, y0=0)
-
-    assert allclose(t, y, yhat, delay=dt, atol=5e-5)
+from nengo_dl.compat import signals_allclose
 
 
 @pytest.mark.parametrize("Synapse", (Alpha, Triangle))
@@ -75,20 +67,6 @@ def test_alpha_multidim(Simulator, seed):
         assert np.allclose(sim.data[p1], canonical[1], atol=5e-5)
 
 
-def test_linearfilter(Simulator, seed):
-    # The following num, den are for a 4th order analog Butterworth filter,
-    # generated with `scipy.signal.butter(4, 0.1, analog=False)`
-    butter_num = np.array([0.0004166, 0.0016664, 0.0024996, 0.0016664, 0.0004166])
-    butter_den = np.array([1.0, -3.18063855, 3.86119435, -2.11215536, 0.43826514])
-
-    dt = 1e-3
-    synapse = LinearFilter(butter_num, butter_den, analog=False)
-    t, x, yhat = run_synapse(Simulator, seed, synapse, dt=dt)
-    y = synapse.filt(x, dt=dt, y0=0)
-
-    assert allclose(t, y, yhat, delay=dt, atol=1e-4)
-
-
 def test_linear_analog(Simulator, seed):
     dt = 1e-3
 
@@ -103,7 +81,7 @@ def test_linear_analog(Simulator, seed):
     t, x, yhat = run_synapse(Simulator, seed, synapse, dt=dt)
     y = synapse.filt(x, dt=dt, y0=0)
 
-    assert allclose(t, y, yhat, delay=dt, atol=5e-4)
+    assert signals_allclose(t, y, yhat, delay=dt, atol=5e-4)
 
 
 @pytest.mark.parametrize("zero", ("C", "D", "X"))
@@ -129,7 +107,7 @@ def test_zero_matrices(Simulator, zero, seed):
     t, x, yhat = run_synapse(Simulator, seed, synapse, dt=dt)
     y = synapse.filt(x, dt=dt, y0=0)
 
-    assert allclose(t, y, yhat, delay=dt, atol=5e-5)
+    assert signals_allclose(t, y, yhat, delay=dt, atol=5e-5)
 
 
 @pytest.mark.training

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -241,7 +241,7 @@ def test_train_recurrent(Simulator, truncation, seed):
         sim.run_steps(n_steps, data={inp: x[:minibatch_size]})
 
     assert np.sqrt(np.mean((sim.data[p] - y[:minibatch_size]) ** 2)) < (
-        0.1 if truncation else 0.05
+        0.1 if truncation else 0.055
     )
 
 
@@ -1005,24 +1005,6 @@ def test_train_state_save(Simulator):
         sim2.run_steps(10)
 
     assert np.allclose(sim.data[p], sim2.data[p])
-
-
-def test_gain_bias(Simulator):
-    N = 17
-    D = 2
-
-    gain = np.random.uniform(low=0.2, high=5, size=N)
-    bias = np.random.uniform(low=0.2, high=1, size=N)
-
-    model = nengo.Network()
-    with model:
-        a = nengo.Ensemble(N, D)
-        a.gain = gain
-        a.bias = bias
-
-    with Simulator(model) as sim:
-        assert np.allclose(gain, sim.data[a].gain)
-        assert np.allclose(bias, sim.data[a].bias)
 
 
 def test_simulation_data(Simulator, seed):

--- a/nengo_dl/tests/test_transforms.py
+++ b/nengo_dl/tests/test_transforms.py
@@ -3,7 +3,6 @@
 from distutils.version import LooseVersion
 
 import nengo
-from nengo.exceptions import ValidationError
 import numpy as np
 import pytest
 
@@ -75,8 +74,8 @@ def test_merge_conv(Simulator, channels_last, seed, pytestconfig):
     with nengo.Simulator(net) as canonical:
         canonical.step()
 
-    assert np.allclose(sim.data[p_b], canonical.data[p_b])
-    assert np.allclose(sim.data[p_c], canonical.data[p_c])
+    assert np.allclose(sim.data[p_b], canonical.data[p_b], atol=5e-6)
+    assert np.allclose(sim.data[p_c], canonical.data[p_c], atol=5e-6)
 
 
 @pytest.mark.skipif(
@@ -103,90 +102,6 @@ def test_conv_error(Simulator, d):
         assert d == 4
     else:
         assert d == 3
-
-
-@pytest.mark.skipif(
-    LooseVersion(nengo.__version__) <= "2.8.0",
-    reason="Nengo Convolutions not implemented",
-)
-@pytest.mark.parametrize("dimensions", (1, 2))
-@pytest.mark.parametrize("padding", ("same", "valid"))
-@pytest.mark.parametrize("channels_last", (True, False))
-@pytest.mark.parametrize("fixed_kernel", (True, False))
-def test_convolution(
-    dimensions, padding, channels_last, fixed_kernel, Simulator, rng, seed
-):
-    # This test is a copy of nengo/tests/test_transforms.py::test_convolution
-    # with only the `allclose` tolerance modified.
-    from nengo._vendor.npconv2d import conv2d
-
-    input_d = 4
-    input_channels = 2
-    output_channels = 5
-    kernel_d = 3
-    kernel_size = (kernel_d,) if dimensions == 1 else (kernel_d, kernel_d)
-    output_d = input_d - kernel_d // 2 * 2 if padding == "valid" else input_d
-
-    input_shape = (input_d, input_channels)
-    kernel_shape = (kernel_d, input_channels, output_channels)
-    output_shape = (output_d, output_channels)
-
-    if dimensions == 2:
-        input_shape = (input_d,) + input_shape
-        kernel_shape = (kernel_d,) + kernel_shape
-        output_shape = (output_d,) + output_shape
-
-    if not channels_last:
-        input_shape = tuple(np.roll(input_shape, 1))
-        output_shape = tuple(np.roll(output_shape, 1))
-
-    with nengo.Network(seed=seed) as net:
-        x = rng.randn(*input_shape)
-        w = rng.randn(*kernel_shape) if fixed_kernel else nengo.dists.Uniform(-0.1, 0.1)
-
-        a = nengo.Node(np.ravel(x))
-        b = nengo.Node(size_in=np.prod(output_shape))
-        conn = nengo.Connection(
-            a,
-            b,
-            synapse=None,
-            transform=nengo.Convolution(
-                output_channels,
-                input_shape,
-                init=w,
-                padding=padding,
-                kernel_size=kernel_size,
-                strides=(1,) if dimensions == 1 else (1, 1),
-                channels_last=channels_last,
-            ),
-        )
-        p = nengo.Probe(b)
-
-        # check error handling
-        bad_in = nengo.Node([0])
-        bad_out = nengo.Node(size_in=5)
-        with pytest.raises(ValidationError):
-            nengo.Connection(bad_in, b, transform=conn.transform)
-        with pytest.raises(ValidationError):
-            nengo.Connection(a, bad_out, transform=conn.transform)
-
-    assert conn.transform.output_shape.shape == output_shape
-    assert conn.transform.kernel_shape == kernel_shape
-
-    with Simulator(net) as sim:
-        sim.step()
-
-    weights = sim.data[conn].weights
-    if not channels_last:
-        x = np.moveaxis(x, 0, -1)
-    if dimensions == 1:
-        x = x[:, None, :]
-        weights = weights[:, None, :, :]
-    truth = conv2d.conv2d(x[None, ...], weights, pad=padding.upper())[0]
-    if not channels_last:
-        truth = np.moveaxis(truth, -1, 0)
-
-    assert np.allclose(sim.data[p][0], np.ravel(truth), atol=1e-6)
 
 
 @pytest.mark.skipif(

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,8 +46,7 @@ max-complexity = 10
 max-line-length = 88
 
 [tool:pytest]
-addopts = -p nengo.tests.options --simulator nengo_dl.Simulator --ref-simulator nengo_dl.Simulator --disable-warnings
-xfail_strict = True
+addopts = --disable-warnings
 norecursedirs =
     .*
     *.egg
@@ -56,45 +55,45 @@ norecursedirs =
     docs
 filterwarnings =
     always
+xfail_strict = True
+nengo_simloader = nengo_dl.tests.make_test_sim
 nengo_test_unsupported =
-    nengo/tests/test_simulator.py:test_warn_on_opensim_del
+    tests/test_simulator.py::test_warn_on_opensim_del
         "nengo_dl raises a different (more visible) warning, see
-        tests/test_nengo_tests.py:test_warn_on_opensim_del"
-    nengo/tests/test_simulator.py:test_signal_init_values
+        tests/test_nengo_tests.py::test_warn_on_opensim_del"
+    tests/test_simulator.py::test_signal_init_values
         "different method required to manually step simulator, see
-        tests/test_nengo_tests.py:test_signal_init_values"
-    nengo/tests/test_simulator.py:test_entry_point
+        tests/test_nengo_tests.py::test_signal_init_values"
+    tests/test_simulator.py::test_entry_point
         "overridden so we can pass custom test simulators, see
-        tests/test_nengo_tests.py:test_entry_point"
-    nengo/tests/test_simulator.py:test_simulator_progress_bars
+        tests/test_nengo_tests.py::test_entry_point"
+    tests/test_simulator.py::test_simulator_progress_bars
         "nengo_dl uses a different progress bar system, see
-        tests/test_utils.py:test_progress_bar"
-    nengo/tests/test_simulator.py:test_dtype[*
+        tests/test_utils.py::test_progress_bar"
+    tests/test_simulator.py::test_dtype[*
         "nengo_dl uses a different system for signals/dtype, see
-        tests/test_nengo_tests.py:test_dtype"
-    nengo/tests/test_node.py:test_args
+        tests/test_nengo_tests.py::test_dtype"
+    tests/test_node.py::test_args
         "time is passed as np.float32, not a float, see
-        tests/test_nengo_tests.py:test_args"
-    nengo/tests/test_node.py:test_unconnected_node
+        tests/test_nengo_tests.py::test_args"
+    tests/test_node.py::test_unconnected_node
         "need to set `unroll_simulation` to ensure node runs the correct number of
-        times, see tests/test_nengo_tests.py:test_unconnected_node"
-    nengo/tests/test_synapses.py:test_alpha
-        "need to set looser tolerances due to float32 implementation, see
-        tests/test_processes.py:test_alpha"
-    nengo/tests/test_synapses.py:test_linearfilter
-        "need to set looser tolerances due to float32 implementation, see
-        tests/test_processes.py:test_linearfilter"
-    nengo/tests/test_ensemble.py:test_gain_bias
-        "use allclose instead of array_equal, see tests/test_simulator.py:test_gain_bias"
-    nengo/tests/test_transforms.py:test_convolution*
-        "need to set looser tolerances due to float32 implementation, see
-        tests/test_transforms.py:test_convolution"
-    nengo/tests/test_transforms.py:test_sparse[False-*
+        times, see tests/test_nengo_tests.py::test_unconnected_node"
+    tests/test_ensemble.py::test_gain_bias
+        "use allclose instead of array_equal, see
+        tests/test_nengo_tests.py::test_gain_bias"
+    tests/test_transforms.py::test_sparse[False-*
         "nengo-dl doesn't raise a warning for scipy=False, see
-        tests/test_nengo_tests.py:test_sparse"
-    nengo/tests/test_copy.py:test_pickle_sim[*
+        tests/test_nengo_tests.py::test_sparse"
+    tests/test_copy.py::test_pickle_sim[*
         "nengo-dl does not support pickling a Simulator, see
-        tests/test_simulator.py:test_pickle_error"
+        tests/test_simulator.py::test_pickle_error"
+allclose_tolerances =
+    tests/test_synapses.py::test_lowpass atol=5e-7
+    tests/test_synapses.py::test_triangle atol=5e-7
+    tests/test_synapses.py::test_alpha atol=5e-5
+    tests/test_synapses.py::test_linearfilter atol=1e-4
+    tests/test_transforms.py::test_convolution[* atol=1e-6
 
 [pylint]
 # note: pylint doesn't look in setup.cfg by default, need to call it with

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,9 @@ tests_req = [
     "nbval>=0.6.0",
     "pylint>=1.9.2",
     "pytest>=3.6.0,<4.1.0",
+    "pytest-allclose>=1.0.0",
     "pytest-cov>=2.6.0",
+    "pytest-rng>=1.0.0",
     "pytest-xdist>=1.16.0,<1.28.0",
     "six>=1.11.0",
 ]


### PR DESCRIPTION
Removes dependence on Nengo's `conftest.py`, except for one remaining part where we're monkey-patching core's `Simulator` fixture.

Also disables autodoc on the `MessageBar` widget. The sphinx 2.2.0 release raises some mysterious error for the (minimal) docstrings in that object.  Looked into it briefly, but not clear why it's erroring (I suspect it's just a bug on sphinx's end). But it's not critical to have in the documentation since it isn't user facing, and will hopefully be replaced by the Keras progress bar system in the near future, so just disabled it to avoid the problem.