### PR TITLE
Allow Simulator learning phase to be controlled by global Keras learning phase

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ Release History
   simulation inside a symbolic TensorFlow loop. This may improve simulation speed,
   but the simulation can only run for exactly ``unroll_simulation`` timesteps.
 - NengoDL now requires ``jinja2`` (used to template some of the docstrings).
+- Added an ``inputs`` argument to ``Simulator.check_gradients``, which can be used to
+  control the initial value of input Nodes during the gradient calculations.
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -124,6 +124,9 @@ Release History
   `TensorFlow/Keras integration
   <https://www.nengo.ai/nengo-dl/examples/tensorflow-models.html>`_ example, and the
   new `Tips and tricks <https://www.nengo.ai/nengo-dl/tips.html>`_ page).
+- The training/inference build logic (e.g., swapping spiking neurons with rate
+  implementations) can be overridden by setting the global Keras learning phase
+  (``tf.keras.backend.set_learning_phase``) before the Simulator is constructed.
 
 **Deprecated**
 

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -11,6 +11,7 @@ from nengo import Connection, Process
 from nengo.builder.operator import SimPyFunc, Reset
 from nengo.builder.processes import SimProcess
 from nengo.config import ConfigError
+from nengo.exceptions import BuildError
 from nengo.neurons import Direct
 import numpy as np
 import tensorflow as tf
@@ -300,6 +301,12 @@ class TensorGraph(tf.keras.layers.Layer):
         """
 
         super().call(inputs, training=training)
+
+        if training == 1 and self.inference_only:
+            raise BuildError(
+                "TensorGraph was created with inference_only=True; cannot be built "
+                "with training=%s" % training
+            )
 
         tf.random.set_seed(self.seed)
 

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -280,13 +280,13 @@ def test_recurrent_gradients(Simulator, seed):
     with nengo.Network(seed=seed) as net:
         a = nengo.Node([0])
         b = nengo.Ensemble(
-            10, 1, gain=nengo.dists.Choice([0.5]), bias=nengo.dists.Choice([-0.1])
+            10, 1, gain=nengo.dists.Choice([0.5]), bias=nengo.dists.Choice([0])
         )
         nengo.Connection(a, b.neurons, transform=nengo.dists.Gaussian(0, 1))
         p = nengo.Probe(b.neurons)
 
     with Simulator(net) as sim:
-        sim.check_gradients([p])
+        sim.check_gradients(inputs=[np.ones((1, sim.unroll * 2, 1)) * 0.1], outputs=[p])
 
 
 @pytest.mark.parametrize("unroll", (1, 2))
@@ -320,7 +320,7 @@ def test_train_objective(Simulator, unroll, seed):
         sim.compile(tf.optimizers.SGD(1e-2, momentum=0.9), loss={p: obj, p2: obj})
         sim.fit({inp: x}, {p: y, p2: z}, epochs=200, verbose=0)
 
-        sim.check_gradients([p, p2])
+        sim.check_gradients(outputs=[p, p2])
 
         sim.run_steps(n_steps, data={inp: x})
 


### PR DESCRIPTION
By default, the Nengo DL simulator will use the learning phase as set by Keras (i.e. "test" mode for `predict/evaluate`, and "train" mode for `fit`).  However, sometimes it can be useful to be able to override Keras' default behaviour (e.g. if we want to use "train" mode in `predict`, so that we can check the output of a spiking model after its neurons are swapped to the rate equivalents).

This allows the learning phase to be overridden by setting the global Keras learning phase (using, e.g. `tf.keras.backend.set_learning_phase`) before the Simulator is constructed.

Also added an option to control the input values in `check_gradients` (for when we don't want to evaluate the gradients at zero).