### PR TITLE
Fix simulator.fit docstring to reference Model.fit

### DIFF
--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -815,8 +815,8 @@ class Simulator:  # pylint: disable=too-many-public-methods
         stateful : bool
             {{ stateful }}
         kwargs: dict
-            Will be passed on to `tf.keras.Model.evaluate
-            <https://www.tensorflow.org/api_docs/python/tf/keras/Model#evaluate>`_.
+            Will be passed on to `tf.keras.Model.fit
+            <https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit>`_.
 
         Returns
         -------


### PR DESCRIPTION
The **kwargs should reference Keras' Model.fit instead of Model.evaluate.