### PR TITLE
Add LeakyReLU neuron models

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Release history
   (not the training behaviour). (`#119`_)
 - Added ``nengo_dl.LeakyReLU`` and ``nengo_dl.SpikingLeakyReLU`` neuron models.
   (`#126`_)
+- Added support for leaky ReLU Keras layers to ``nengo_dl.Converter``. (`#126`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Release history
   Layers/parameters that cannot be fully converted to native Nengo objects to be
   converted in a way that only matches the inference behaviour of the source Keras model
   (not the training behaviour). (`#119`_)
+- Added ``nengo_dl.LeakyReLU`` and ``nengo_dl.SpikingLeakyReLU`` neuron models.
+  (`#126`_)
 
 **Changed**
 
@@ -63,9 +65,10 @@ Release history
 - Fixed compatibility with ``progressbar2`` version 3.50.0. (`#136`_)
 
 .. _#119: https://github.com/nengo/nengo-dl/pull/119
+.. _#126: https://github.com/nengo/nengo-dl/pull/126
 .. _#128: https://github.com/nengo/nengo-dl/pull/128
-.. _Nengo#1591: https://github.com/nengo/nengo/pull/1591
 .. _#136: https://github.com/nengo/nengo-dl/pull/136
+.. _Nengo#1591: https://github.com/nengo/nengo/pull/1591
 
 3.0.0 (December 17, 2019)
 -------------------------

--- a/nengo_dl/__init__.py
+++ b/nengo_dl/__init__.py
@@ -58,6 +58,10 @@ from nengo_dl import (
 from nengo_dl import callbacks, compat, converter, dists, losses
 from nengo_dl.config import configure_settings
 from nengo_dl.converter import Converter
-from nengo_dl.neurons import SoftLIFRate
+from nengo_dl.neurons import (
+    LeakyReLU,
+    SoftLIFRate,
+    SpikingLeakyReLU,
+)
 from nengo_dl.simulator import Simulator
 from nengo_dl.tensor_node import TensorNode, Layer, tensor_layer

--- a/nengo_dl/tests/test_converter.py
+++ b/nengo_dl/tests/test_converter.py
@@ -514,3 +514,11 @@ def test_nested_input():
     x = tf.keras.layers.Concatenate()([x, x_0])
 
     _test_convert(inputs, x)
+
+
+def test_leaky_relu(rng):
+    inp = x = tf.keras.Input(shape=(4,))
+    x = tf.keras.layers.ReLU(negative_slope=0.1)(x)
+    x = tf.keras.layers.LeakyReLU(alpha=2)(x)
+
+    _test_convert(inp, x, inp_vals=[rng.uniform(-1, 1, size=(32, 4))])


### PR DESCRIPTION
I went with the name `LeakyReLU`, because `SpikingLeakyRectifiedLinear` was just getting a bit too much I thought.

Based on #119 (since there are some general fixes there).