### PR TITLE
More memory optimizations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ Release history
   parameters in a network as the scalar default ``transform=1`` weights on
   non-Ensemble connections will no longer be present. (`#128`_)
 - Re-enabled the ``remove_constant_copies`` graph simplification by default. (`#129`_)
+- Reduced the amount of state that needs to be stored in the simulation. (`#129`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Release history
 - Added ``nengo_dl.LeakyReLU`` and ``nengo_dl.SpikingLeakyReLU`` neuron models.
   (`#126`_)
 - Added support for leaky ReLU Keras layers to ``nengo_dl.Converter``. (`#126`_)
+- Added a new ``remove_reset_incs`` graph simplification step. (`#129`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ Release history
   non-Ensemble connections will no longer be present. (`#128`_)
 - Re-enabled the ``remove_constant_copies`` graph simplification by default. (`#129`_)
 - Reduced the amount of state that needs to be stored in the simulation. (`#129`_)
+- Added more information to the error message when loading saved parameters that
+  don't match the current model. (`#129`_)
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,7 @@ Release history
   (see `Nengo#1591`_). Note that this may change the number of trainable
   parameters in a network as the scalar default ``transform=1`` weights on
   non-Ensemble connections will no longer be present. (`#128`_)
+- Re-enabled the ``remove_constant_copies`` graph simplification by default. (`#129`_)
 
 **Fixed**
 
@@ -68,6 +69,7 @@ Release history
 .. _#119: https://github.com/nengo/nengo-dl/pull/119
 .. _#126: https://github.com/nengo/nengo-dl/pull/126
 .. _#128: https://github.com/nengo/nengo-dl/pull/128
+.. _#129: https://github.com/nengo/nengo-dl/pull/129
 .. _#136: https://github.com/nengo/nengo-dl/pull/136
 .. _Nengo#1591: https://github.com/nengo/nengo/pull/1591
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -175,6 +175,8 @@ disable sorting via
     with nengo.Network() as net:
         nengo_dl.configure_settings(sorter=noop_order_signals)
 
+.. _config-simplifications:
+
 simplifications
 ---------------
 

--- a/docs/examples/spa-memory.ipynb
+++ b/docs/examples/spa-memory.ipynb
@@ -592,7 +592,7 @@
     "    # download pretrained parameters\n",
     "    urlretrieve(\n",
     "        \"https://drive.google.com/uc?export=download&\"\n",
-    "        \"id=182toR0aSWv1uExA7F5kn8t2lEU1SVrx1\",\n",
+    "        \"id=1aspi_dayS37Rx_IvDuRrXoybdIC_-tkn\",\n",
     "        \"mem_binding_params.npz\")"
    ]
   },

--- a/nengo_dl/benchmarks.py
+++ b/nengo_dl/benchmarks.py
@@ -649,7 +649,7 @@ def run_profile(
                     sim.minibatch_size * n_batches, n_steps, net.inp.size_out
                 )
             }
-        else:
+        elif hasattr(net, "inp_a"):
             x = {
                 net.inp_a: np.random.randn(
                     sim.minibatch_size * n_batches, n_steps, net.inp_a.size_out
@@ -658,6 +658,8 @@ def run_profile(
                     sim.minibatch_size * n_batches, n_steps, net.inp_b.size_out
                 ),
             }
+        else:
+            x = None
 
         if train:
             y = {
@@ -670,14 +672,14 @@ def run_profile(
 
             # run once to eliminate startup overhead
             start = timeit.default_timer()
-            sim.fit(x, y, epochs=1)
+            sim.fit(x, y, epochs=1, n_steps=n_steps)
             print("Warmup time:", timeit.default_timer() - start)
 
             for _ in range(reps):
                 if do_profile:
                     profiler.start()
                 start = timeit.default_timer()
-                sim.fit(x, y, epochs=1)
+                sim.fit(x, y, epochs=1, n_steps=n_steps)
                 exec_time = min(timeit.default_timer() - start, exec_time)
                 if do_profile:
                     profiler.save("profile", profiler.stop())

--- a/nengo_dl/config.py
+++ b/nengo_dl/config.py
@@ -41,7 +41,8 @@ def configure_settings(**kwargs):
     simplifications: list of graph simplification functions
         Pass a list of `graph simplification functions
         <https://www.nengo.ai/nengo-dl/reference.html#graph-optimization>`_ to change
-        the default simplifications applied.
+        the default simplifications applied.  The default list of simplifications
+        can be found in ``nengo_dl.graph_optimizer.default_simplifications``.
     inference_only : bool
         Set to True if the network will only be run in inference mode (i.e.,
         no calls to `.Simulator.fit`).  This may result in a small

--- a/nengo_dl/learning_rule_builders.py
+++ b/nengo_dl/learning_rule_builders.py
@@ -2,7 +2,6 @@
 Build classes for Nengo learning rule operators.
 """
 
-from nengo import rc as nengo_rc
 from nengo.builder import Signal
 from nengo.builder.learning_rules import (
     SimBCM,
@@ -206,7 +205,7 @@ def build_pes(model, pes, rule):
     conn = rule.connection
 
     # Create input error signal
-    error = Signal(np.zeros(rule.size_in, dtype=nengo_rc.float_dtype), name="PES:error")
+    error = Signal(shape=(rule.size_in,), name="PES:error")
     model.add_op(Reset(error))
     model.sig[rule]["in"] = error  # error connection will attach here
 
@@ -222,17 +221,13 @@ def build_pes(model, pes, rule):
             # in order to avoid slicing encoders along an axis > 0, we pad
             # `error` out to the full base dimensionality and then do the
             # dotinc with the full encoder matrix
-            padded_error = Signal(
-                np.zeros(encoders.shape[1], dtype=nengo_rc.float_dtype)
-            )
+            padded_error = Signal(shape=(encoders.shape[1],))
             model.add_op(Copy(error, padded_error, dst_slice=conn.post_slice))
         else:
             padded_error = error
 
         # error = dot(encoders, error)
-        local_error = Signal(
-            np.zeros(post.n_neurons, dtype=nengo_rc.float_dtype), name="PES:encoded"
-        )
+        local_error = Signal(shape=(post.n_neurons,))
         model.add_op(Reset(local_error))
         model.add_op(DotInc(encoders, padded_error, local_error, tag="PES:encode"))
     else:

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -1208,6 +1208,11 @@ class Simulator:  # pylint: disable=too-many-public-methods
         )
 
         with np.load(path + ".npz") as vals:
+            if len(vars) != len(vals.files):
+                raise SimulationError(
+                    "Number of saved parameters in %s (%d) != number of variables in "
+                    "the model (%d)" % (path, len(vals.files), len(vars))
+                )
             tf.keras.backend.batch_set_value(
                 zip(vars, (vals["arr_%d" % i] for i in range(len(vals.files))))
             )

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -1935,16 +1935,12 @@ class Simulator:  # pylint: disable=too-many-public-methods
 
     @with_self
     def _update_steps(self):
-        if not hasattr(self, "_step_tensors"):
-            # cache these so we aren't adding new ops every time we call this function
-            self._step_tensors = [
-                self.tensor_graph.get_tensor(self.model.step),
-                self.tensor_graph.get_tensor(self.model.time),
-            ]
+        if not hasattr(self, "_step_tensor"):
+            # cache this so we aren't adding new ops every time we call this function
+            self._step_tensor = self.tensor_graph.get_tensor(self.model.step)
 
-        self._n_steps, self._time = [
-            x.item() for x in tf.keras.backend.batch_get_value(self._step_tensors)
-        ]
+        self._n_steps = tf.keras.backend.get_value(self._step_tensor).item()
+        self._time = self._n_steps * self.dt
 
     @property
     def dt(self):

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -115,14 +115,7 @@ class TensorGraph(tf.keras.layers.Layer):
 
         # apply graph simplification functions
         simplifications = config.get_setting(
-            model,
-            "simplifications",
-            [
-                graph_optimizer.remove_unmodified_resets,
-                graph_optimizer.remove_zero_incs,
-                graph_optimizer.remove_identity_muls,
-                graph_optimizer.remove_constant_copies,
-            ],
+            model, "simplifications", graph_optimizer.default_simplifications,
         )
 
         with progress.sub("operator simplificaton", max_value=None):

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -121,6 +121,7 @@ class TensorGraph(tf.keras.layers.Layer):
                 graph_optimizer.remove_unmodified_resets,
                 graph_optimizer.remove_zero_incs,
                 graph_optimizer.remove_identity_muls,
+                graph_optimizer.remove_constant_copies,
             ],
         )
 

--- a/nengo_dl/tensor_node.py
+++ b/nengo_dl/tensor_node.py
@@ -9,7 +9,6 @@ details.
 import warnings
 
 from nengo import Node, Connection, Ensemble, builder
-from nengo import rc as nengo_rc
 from nengo.base import NengoObject
 from nengo.builder.operator import Reset
 from nengo.config import Config
@@ -248,16 +247,12 @@ def build_tensor_node(model, node):
 
     # input signal
     if node.shape_in is not None:
-        sig_in = builder.Signal(
-            np.zeros(node.size_in, dtype=nengo_rc.float_dtype), name="%s.in" % node
-        )
+        sig_in = builder.Signal(shape=(node.size_in,), name="%s.in" % node)
         model.add_op(Reset(sig_in))
     else:
         sig_in = None
 
-    sig_out = builder.Signal(
-        np.zeros(node.size_out, dtype=nengo_rc.float_dtype), name="%s.out" % node
-    )
+    sig_out = builder.Signal(shape=(node.size_out,), name="%s.out" % node)
 
     model.sig[node]["in"] = sig_in
     model.sig[node]["out"] = sig_out

--- a/nengo_dl/tests/test_benchmarks.py
+++ b/nengo_dl/tests/test_benchmarks.py
@@ -190,10 +190,10 @@ def test_lmu(Simulator, native_nengo, pytestconfig):
 @pytest.mark.parametrize(
     "net, train, minibatch_size, min, max",
     [
-        (benchmarks.cconv(128, 64, nengo.RectifiedLinear()), False, 64, 0.65, 0.8),
-        (benchmarks.cconv(128, 64, nengo.LIF()), False, 64, 1.45, 1.65),
-        (benchmarks.integrator(128, 32, nengo.RectifiedLinear()), True, 64, 0.6, 1.0),
-        (benchmarks.integrator(128, 32, nengo.LIF()), True, 64, 1.1, 1.4),
+        (benchmarks.cconv(128, 64, nengo.RectifiedLinear()), False, 64, 0.6, 0.75),
+        (benchmarks.cconv(128, 64, nengo.LIF()), False, 64, 1.4, 1.6),
+        (benchmarks.integrator(128, 32, nengo.RectifiedLinear()), True, 64, 0.55, 0.95),
+        (benchmarks.integrator(128, 32, nengo.LIF()), True, 64, 1.0, 1.3),
         (
             benchmarks.random_network(
                 64,

--- a/nengo_dl/tests/test_benchmarks.py
+++ b/nengo_dl/tests/test_benchmarks.py
@@ -101,7 +101,9 @@ def _test_random(
     assert all(net.inp in x for x in post_conns.values())
 
 
-@pytest.mark.parametrize("network, train", [("integrator", True), ("cconv", False)])
+@pytest.mark.parametrize(
+    "network, train", [("integrator", True), ("cconv", False), ("test", True)]
+)
 def test_run_profile(network, train, pytestconfig, monkeypatch, tmpdir):
     monkeypatch.chdir(tmpdir)
 
@@ -109,6 +111,10 @@ def test_run_profile(network, train, pytestconfig, monkeypatch, tmpdir):
         net = benchmarks.integrator(3, 2, nengo.SpikingRectifiedLinear())
     elif network == "cconv":
         net = benchmarks.cconv(3, 10, nengo.LIF())
+    elif network == "test":
+        with nengo.Network() as net:
+            ens = nengo.Ensemble(10, 1)
+            net.p = nengo.Probe(ens)
 
     benchmarks.run_profile(
         net,

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -591,6 +591,10 @@ def test_save_load_params(Simulator, include_non_trainable, tmpdir):
         else:
             assert not np.allclose(sim_load.data[p1], sim_save.data[p0][10:])
 
+    with Simulator(nengo.Network()) as sim:
+        with pytest.raises(SimulationError, match="!= number of variables"):
+            sim.load_params(str(tmpdir))
+
 
 def test_model_passing(Simulator, seed):
     # make sure that passing a built model to the Simulator works properly

--- a/nengo_dl/tests/test_tensor_graph.py
+++ b/nengo_dl/tests/test_tensor_graph.py
@@ -229,7 +229,10 @@ def test_signal_order_deterministic(Simulator, seed):
                     sim1.tensor_graph.base_arrays_init[trainable].values(),
                     sim2.tensor_graph.base_arrays_init[trainable].values(),
                 ):
-                    assert np.allclose(v[0], v2[0])
+                    assert all(
+                        (x is None and y is None) or np.allclose(x, y)
+                        for x, y in zip(v[0], v2[0])
+                    )
 
 
 def test_create_signals():

--- a/nengo_dl/tests/test_tensor_node.py
+++ b/nengo_dl/tests/test_tensor_node.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-from distutils.version import LooseVersion
 from functools import partial
 
 import nengo
@@ -262,19 +261,12 @@ def test_reuse_vars(Simulator, pytestconfig):
         assert np.allclose(sim.data[p2], 3)
 
         # note: when inference-only=True the weights will be marked as non-trainable
-
-        default_conn_params = 2 if LooseVersion(nengo.__version__) < "3.1.0" else 0
-
         if sim.tensor_graph.inference_only:
-            assert (
-                len(sim.keras_model.non_trainable_variables) == 8 + default_conn_params
-            )
+            assert len(sim.keras_model.non_trainable_variables) == 4
             assert len(sim.keras_model.trainable_variables) == 0
             vars = sim.keras_model.non_trainable_variables[-2:]
         else:
-            assert (
-                len(sim.keras_model.non_trainable_variables) == 6 + default_conn_params
-            )
+            assert len(sim.keras_model.non_trainable_variables) == 2
             assert len(sim.keras_model.trainable_variables) == 2
             vars = sim.keras_model.trainable_variables
 


### PR DESCRIPTION
The main change here is avoiding storing simulator state for signals targeted by `set` operations (since that state will never be read).  

I also added some more graph simplification functions.  One (`remove_constant_copies`), I had previously disabled because it could change which signals are stored by `save_params`/`load_params`. But thinking about this more, that doesn't seem worth disabling it for. As long as the user is consistently using (or not using) `remove_constant_copies` in both networks, then save/load params will work fine. So better to have it enabled by default (users can still disable it if they run into problems).

The second one `remove_reset_incs`, I had previously completely removed because in general it seemed to make things worse. But I realized that this was largely to do with the kinds of networks we often build in Nengo, which have a lot of horizontal parallelism. In more deep learning style networks, where you just have a big long chain of objects, `remove_reset_incs` can still be helpful. And then with some further testing, I didn't really see any significant performance decreases when enabling it by default, so I just went with that.