### PR TITLE
Converter improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,8 @@ Release history
 - Added ``tensorflow-cpu`` distributions to installation checks (so Nengo DL will
   not attempt to reinstall TensorFlow if ``tensorflow-cpu`` is already installed).
   (`#142`_)
+- Fixed bug when applying the Converter to Keras models that re-use intermediate
+  layers as output layers. (`#137`_)
 
 **Deprecated**
 
@@ -88,6 +90,7 @@ Release history
 .. _#129: https://github.com/nengo/nengo-dl/pull/129
 .. _#130: https://github.com/nengo/nengo-dl/pull/130
 .. _#134: https://github.com/nengo/nengo-dl/pull/134
+.. _#137: https://github.com/nengo/nengo-dl/pull/137
 .. _#139: https://github.com/nengo/nengo-dl/pull/139
 .. _#140: https://github.com/nengo/nengo-dl/pull/140
 .. _#142: https://github.com/nengo/nengo-dl/pull/142

--- a/nengo_dl/tests/test_converter.py
+++ b/nengo_dl/tests/test_converter.py
@@ -701,3 +701,20 @@ def test_layer_dicts():
 
     assert conv.outputs[x0].target is conv.layers[x0]
     assert conv.outputs[x1].target is conv.layers[x1]
+
+
+def test_mid_model_output(Simulator):
+    """Check that converter supports output tensors from the middle of the model.
+
+    Previous converter put output tensors last in build order, so having an output
+    tensor that needed to be built before non-output tensors was problematic.
+    https://github.com/nengo/nengo-dl/pull/137
+    """
+
+    # model must have at least three layers, with one layer in between outputs
+    inp = tf.keras.Input(shape=(1,))
+    x0 = tf.keras.layers.ReLU()(inp)
+    x1 = tf.keras.layers.ReLU()(x0)
+    x2 = tf.keras.layers.ReLU()(x1)
+
+    _test_convert(inp, [x0, x2], inp_vals=[np.ones((4, 1))])


### PR DESCRIPTION
Some improvements to get the Keras converter working with my network.

- Do not sort `source_tensor` list. This is no longer required, and is problematic for models that have an output that is used other places in the model (since the sorting puts all outputs at the end).
- ~~Use a single bias connection in `inference_only` mode. We don't need to worry about proper bias sharing since we're not training them. It's much faster to use one connection to do all the biases in this case.~~

TODO:
- [x] Add a test of a network that has a middle layer as an output