### PR TITLE
Don't include saved state in keras_model.weights

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,14 +82,15 @@ jobs:
         distributions: "sdist "
         on:
           all_branches: true
+          tags: false
           condition: $TRAVIS_BRANCH =~ ^release-candidate-*
-          condition: $TRAVIS_TAG = ""
       - provider: pypi
         user: drasmuss
         password: $PYPI_TOKEN
         distributions: "sdist "
         on:
           all_branches: true
+          tags: true
           condition: $TRAVIS_TAG =~ ^v[0-9]*
 
 before_install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,27 @@ Release history
 3.1.1 (unreleased)
 ------------------
 
+**Changed**
+
+- Saved simulator state will no longer be included in ``Simulator.keras_model.weights``.
+  This means that ``Simulator.keras_model.save/load_weights`` will not include the
+  saved simulator state, making it easier to reuse weights between models (as long as
+  the models have the same weights, they do not need to have the same state variables).
+  ``Simulator.save/load_params(..., include_state=True)`` can be used to explicitly
+  save the simulator state, if desired. (`#140`_)
+- Model parameters (e.g., connection weights) that are not trainable (because they've
+  been marked non-trainable by user or targeted by an online learning rule) will now
+  be treated separately from simulator state. For example,
+  ``Simulator.save_params(..., include_state=False)`` will still include those
+  parameters, and the results of any online learning will persist between calls even
+  with ``stateful=False``. (`#140`_)
+
+**Deprecated**
+
+- Renamed ``Simulator.save/load_params`` ``include_non_trainable`` parameter to
+  ``include_state``. (`#140`_)
+
+.. _#140: https://github.com/nengo/nengo-dl/pull/140
 
 3.1.0 (March 4, 2020)
 ---------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Release history
 3.1.1 (unreleased)
 ------------------
 
+**Added**
+
+- Compatible with TensorFlow 2.2.0. (`#140`_)
+
 **Changed**
 
 - Saved simulator state will no longer be included in ``Simulator.keras_model.weights``.

--- a/docs/examples/lmu.ipynb
+++ b/docs/examples/lmu.ipynb
@@ -253,7 +253,7 @@
     "    else:\n",
     "        urlretrieve(\n",
     "            \"https://drive.google.com/uc?export=download&\"\n",
-    "            \"id=1qhKmpnipk8AK2bsilPlJBFQg1t7XAEZr\",\n",
+    "            \"id=1epcfVDdUaHkwNo1kD4kjIF7qlXgJmb2i\",\n",
     "            \"lmu_params.npz\")\n",
     "        sim.load_params(\"./lmu_params\")\n",
     "\n",

--- a/docs/examples/spa-memory.ipynb
+++ b/docs/examples/spa-memory.ipynb
@@ -592,7 +592,7 @@
     "    # download pretrained parameters\n",
     "    urlretrieve(\n",
     "        \"https://drive.google.com/uc?export=download&\"\n",
-    "        \"id=1aspi_dayS37Rx_IvDuRrXoybdIC_-tkn\",\n",
+    "        \"id=1Ym44i2sBLbNUiNgJaP3l1Obhf_NFenU7\",\n",
     "        \"mem_binding_params.npz\")"
    ]
   },

--- a/nengo_dl/config.py
+++ b/nengo_dl/config.py
@@ -22,7 +22,7 @@ def configure_settings(**kwargs):
     Parameters
     ----------
     trainable : bool or None
-        Adds a parameter to Nengo Ensembles/Connections/Networks that controls
+        Adds a parameter to Nengo Ensembles/Connections that controls
         whether or not they will be optimized by `.Simulator.fit`.
         Passing ``None`` will use the default ``nengo_dl`` trainable settings,
         or True/False will override the default for all objects.  In either

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -28,7 +28,6 @@ from nengo.solvers import NoSolver
 from nengo.utils.magic import decorator
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.keras import backend
 
 from nengo_dl import callbacks, compat, config, utils
 from nengo_dl.builder import NengoBuilder, NengoModel
@@ -550,9 +549,7 @@ class Simulator:  # pylint: disable=too-many-public-methods
             inputs,
             stateful=self.stateful,
             # if the global learning phase is set, use that
-            training=backend._GRAPH_LEARNING_PHASES.get(
-                backend._DUMMY_EAGER_GRAPH, None
-            ),
+            training=compat.global_learning_phase(),
             progress=progress,
         )
 

--- a/nengo_dl/tests/test_objectives.py
+++ b/nengo_dl/tests/test_objectives.py
@@ -9,7 +9,6 @@ from nengo_dl import losses
 
 
 @pytest.mark.parametrize("axis, order", [(None, 1), (None, "euclidean"), (1, 2)])
-@pytest.mark.training
 def test_regularize(axis, order, rng):
     x_init = rng.randn(2, 3, 4, 5)
 

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -809,16 +809,18 @@ def test_profile(Simulator, mode, tmpdir):
     net, a, p = dummies.linear_net()
 
     with Simulator(net) as sim:
+        # note: TensorFlow bug if using profile_batch=1, see
+        # https://github.com/tensorflow/tensorflow/issues/37543
         callback = callbacks.TensorBoard(
-            log_dir=str(tmpdir.join("profile")), profile_batch=1
+            log_dir=str(tmpdir.join("profile")), profile_batch=2
         )
 
         if mode == "predict":
-            sim.predict(n_steps=5, callbacks=[callback])
+            sim.predict(np.zeros((2, 5, 1)), callbacks=[callback])
         else:
             sim.compile(tf.optimizers.SGD(1), loss=tf.losses.mse)
             sim.fit(
-                {a: np.zeros((1, 5, 1))}, {p: np.zeros((1, 5, 1))}, callbacks=[callback]
+                {a: np.zeros((2, 5, 1))}, {p: np.zeros((2, 5, 1))}, callbacks=[callback]
             )
 
         assert os.path.exists(str(tmpdir.join("profile", "train")))

--- a/nengo_dl/tests/test_tensor_node.py
+++ b/nengo_dl/tests/test_tensor_node.py
@@ -262,11 +262,13 @@ def test_reuse_vars(Simulator, pytestconfig):
 
         # note: when inference-only=True the weights will be marked as non-trainable
         if sim.tensor_graph.inference_only:
-            assert len(sim.keras_model.non_trainable_variables) == 4
-            assert len(sim.keras_model.trainable_variables) == 0
-            vars = sim.keras_model.non_trainable_variables[-2:]
-        else:
+            assert len(sim.tensor_graph.saved_state) == 2
             assert len(sim.keras_model.non_trainable_variables) == 2
+            assert len(sim.keras_model.trainable_variables) == 0
+            vars = sim.keras_model.non_trainable_variables
+        else:
+            assert len(sim.tensor_graph.saved_state) == 2
+            assert len(sim.keras_model.non_trainable_variables) == 0
             assert len(sim.keras_model.trainable_variables) == 2
             vars = sim.keras_model.trainable_variables
 


### PR DESCRIPTION
This makes it easier to re-use saved weights between models, as models with different saved state variables can still use the same saved Keras parameters.

Fixes #133 