### PR TITLE
Fix bug in converting Dense layers with fallback activation functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -84,6 +84,8 @@ Release history
   (`#142`_)
 - Fixed bug when applying the Converter to Keras models that re-use intermediate
   layers as output layers. (`#137`_)
+- Fixed bug in conversion of Keras Dense layers with non-native activation functions.
+  (`#144`_)
 
 **Deprecated**
 
@@ -102,6 +104,7 @@ Release history
 .. _#140: https://github.com/nengo/nengo-dl/pull/140
 .. _#141: https://github.com/nengo/nengo-dl/pull/141
 .. _#142: https://github.com/nengo/nengo-dl/pull/142
+.. _#144: https://github.com/nengo/nengo-dl/pull/144
 
 3.1.0 (March 4, 2020)
 ---------------------

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -83,6 +83,11 @@ if LooseVersion(tf.__version__) < "2.2.0":
 
         return backend._GRAPH_LEARNING_PHASES.get(backend._DUMMY_EAGER_GRAPH, None)
 
+    def tensor_ref(tensor):
+        """Return (experimental) Tensor ref (can be used as dict key)."""
+
+        return tensor.experimental_ref()
+
 
 else:
 
@@ -90,6 +95,11 @@ else:
         """Returns the global (eager) Keras learning phase."""
 
         return backend._GRAPH_LEARNING_PHASES.get(backend._DUMMY_EAGER_GRAPH.key, None)
+
+    def tensor_ref(tensor):
+        """Return Tensor ref (can be used as dict key)."""
+
+        return tensor.ref()
 
     # monkeypatch to fix bug in TF2.2, see
     # https://github.com/tensorflow/tensorflow/issues/37548

--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -11,6 +11,7 @@ import tensorflow as tf
 from tensorflow.python.keras.layers import BatchNormalization, BatchNormalizationV2
 from tensorflow.python.util import nest
 
+from nengo_dl import compat
 from nengo_dl.config import configure_settings
 from nengo_dl.neurons import LeakyReLU
 from nengo_dl.simulator import Simulator
@@ -389,7 +390,7 @@ class Converter:
 
             if isinstance(key, tf.Tensor):
                 # get hashable key
-                key = key.experimental_ref()
+                key = compat.tensor_ref(key)
 
             return key
 


### PR DESCRIPTION
Two bugs being fixed here:
1. `shape_in` of the fallback activation TensorNode was being set incorrectly (should be `output_shape` not `input_shape`)
2. Biases were not being added to converted Dense layers with fallback activation functions.