### PR TITLE
Support Sparse transforms in Simulator.get_nengo_params

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -80,6 +80,7 @@ setup_cfg:
   pylint:
     known_third_party:
       - PIL
+      - packaging
       - progressbar
       - tensorflow
   coverage:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,11 @@ Release history
 3.2.1 (unreleased)
 ------------------
 
+**Fixed**
+
+- Support Sparse transforms in ``Simulator.get_nengo_params``. (`#149`_)
+
+.. _#149: https://github.com/nengo/nengo-dl/pull/149
 
 3.2.0 (April 2, 2020)
 ---------------------

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -134,6 +134,8 @@ else:
 linalg_onenormest.aslinearoperator = linalg_interface.aslinearoperator
 
 if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
+    NoTransform = type(None)
+
     default_transform = 1
 
     def conn_has_weights(conn):
@@ -142,6 +144,8 @@ if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
 
 
 else:
+    from nengo.transforms import NoTransform
+
     default_transform = None
 
     def conn_has_weights(conn):

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -5,10 +5,10 @@ Utilities to ease cross-compatibility between different versions of upstream
 dependencies.
 """
 
-from distutils.version import LooseVersion
 
 import nengo
 from nengo._vendor.scipy.sparse import linalg_interface, linalg_onenormest
+from packaging import version
 import tensorflow as tf
 from tensorflow.python.keras import backend
 from tensorflow.python.keras.engine import network
@@ -76,7 +76,7 @@ class TFLogFilter:
 
 tf.get_logger().addFilter(TFLogFilter(err_on_deprecation=False))
 
-if LooseVersion(tf.__version__) < "2.2.0":
+if version.parse(tf.__version__) < version.parse("2.2.0rc0"):
 
     def global_learning_phase():
         """Returns the global (eager) Keras learning phase."""
@@ -122,7 +122,7 @@ else:
 # monkeypatch fix for https://github.com/nengo/nengo/pull/1587
 linalg_onenormest.aslinearoperator = linalg_interface.aslinearoperator
 
-if LooseVersion(nengo.__version__) < "3.1.0":
+if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
     default_transform = 1
 
     def conn_has_weights(conn):

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -117,6 +117,17 @@ else:
 
     network.Network._conform_to_reference_input = _conform_to_reference_input
 
+if version.parse(tf.__version__) < version.parse("2.1.0rc0"):
+    from tensorflow.python.keras.layers import (
+        BatchNormalization as BatchNormalizationV1,
+    )
+    from tensorflow.python.keras.layers import BatchNormalizationV2
+else:
+    from tensorflow.python.keras.layers import (
+        BatchNormalizationV1,
+        BatchNormalizationV2,
+    )
+
 # Nengo compatibility
 
 # monkeypatch fix for https://github.com/nengo/nengo/pull/1587

--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -8,7 +8,6 @@ import warnings
 import nengo
 import numpy as np
 import tensorflow as tf
-from tensorflow.python.keras.layers import BatchNormalization, BatchNormalizationV2
 from tensorflow.python.util import nest
 
 from nengo_dl import compat
@@ -1170,8 +1169,8 @@ class ConvertAvgPool3D(ConvertAvgPool):
         return super().convert(node_id, dimensions=3)
 
 
-@Converter.register(BatchNormalization)
-@Converter.register(BatchNormalizationV2)
+@Converter.register(compat.BatchNormalizationV1)
+@Converter.register(compat.BatchNormalizationV2)
 class ConvertBatchNormalization(LayerConverter):
     """Convert ``tf.keras.layers.BatchNormalization`` to Nengo objects."""
 
@@ -1308,7 +1307,10 @@ class ConvertConv(LayerConverter):
 
             # add trainable bias weights
             bias_node = nengo.Node([1], label="%s.%d.bias" % (self.layer.name, node_id))
-            bias_relay = nengo.Node(size_in=len(biases))
+            bias_relay = nengo.Node(
+                size_in=len(biases),
+                label="%s.%d.bias_relay" % (self.layer.name, node_id),
+            )
             nengo.Connection(
                 bias_node, bias_relay, transform=biases[:, None], synapse=None
             )

--- a/nengo_dl/graph_optimizer.py
+++ b/nengo_dl/graph_optimizer.py
@@ -1392,7 +1392,7 @@ def remove_identity_muls(operators):
 
         return (
             x.shape == (d, d)
-            and np.allclose(np.diag(x), 1)
+            and np.allclose(x.diagonal(), 1)
             and np.allclose(np.sum(np.abs(x)), d)  # all non-diagonal elements are 0
         )
 

--- a/nengo_dl/tests/test_converter.py
+++ b/nengo_dl/tests/test_converter.py
@@ -1,9 +1,8 @@
 # pylint: disable=missing-docstring
 
-from distutils.version import LooseVersion
-
 import nengo
 import numpy as np
+from packaging import version
 import pytest
 import tensorflow as tf
 from tensorflow.python.keras.layers import BatchNormalization
@@ -175,12 +174,18 @@ def test_batch_normalization(rng):
     # TF<2.1 doesn't support axis!=-1 for fused batchnorm
     out.append(
         tf.keras.layers.BatchNormalization(
-            axis=1, fused=None if LooseVersion(tf.__version__) >= "2.1.0" else False
+            axis=1,
+            fused=False
+            if version.parse(tf.__version__) < version.parse("2.1.0rc0")
+            else None,
         )(inp)
     )
     out.append(
         tf.keras.layers.BatchNormalization(
-            axis=2, fused=None if LooseVersion(tf.__version__) >= "2.1.0" else False
+            axis=2,
+            fused=False
+            if version.parse(tf.__version__) < version.parse("2.1.0rc0")
+            else None,
         )(inp)
     )
     out.append(tf.keras.layers.BatchNormalization()(inp))

--- a/nengo_dl/tests/test_graph_optimizer.py
+++ b/nengo_dl/tests/test_graph_optimizer.py
@@ -1,7 +1,5 @@
 # pylint: disable=missing-docstring
 
-from distutils.version import LooseVersion
-
 import nengo
 from nengo.exceptions import BuildError
 from nengo.neurons import LIF, LIFRate, Izhikevich, AdaptiveLIF
@@ -20,6 +18,7 @@ from nengo.builder.processes import SimProcess
 from nengo.builder.signal import Signal
 from nengo.builder.transforms import ConvInc
 import numpy as np
+from packaging import version
 import pytest
 
 from nengo_dl import config, op_builders, transform_builders
@@ -1183,7 +1182,7 @@ def test_remove_reset_inc_functional(Simulator, seed):
         p = nengo.Probe(node1)
 
     with Simulator(net) as sim:
-        extra_op = LooseVersion(nengo.__version__) < "3.1.0"
+        extra_op = version.parse(nengo.__version__) < version.parse("3.1.0.dev0")
 
         assert len(sim.tensor_graph.plan) == 8 + extra_op
 

--- a/nengo_dl/tests/test_learning_rules.py
+++ b/nengo_dl/tests/test_learning_rules.py
@@ -79,8 +79,8 @@ def test_merged_learning(Simulator, rule, weights, seed):
             assert np.allclose(sim.data[p1][i], canonical[1])
 
 
-def test_online_learning_reset(Simulator, tmpdir):
-    with nengo.Network() as net:
+def test_online_learning_reset(Simulator, tmpdir, seed):
+    with nengo.Network(seed=seed) as net:
         inp = nengo.Ensemble(10, 1)
         out = nengo.Node(size_in=1)
         conn = nengo.Connection(inp, out, learning_rule_type=nengo.PES(1))
@@ -98,12 +98,12 @@ def test_online_learning_reset(Simulator, tmpdir):
         # test that learning has changed weights
         assert not np.allclose(w0, w1)
 
-        # test that soft reset does NOT reset the online learning weights
-        sim.soft_reset()
+        # test that include_trainable=False does NOT reset the online learning weights
+        sim.reset(include_trainable=False)
         assert np.allclose(w1, sim.data[conn].weights)
 
         # test that full reset DOES reset the online learning weights
-        sim.reset()
+        sim.reset(include_trainable=True)
         assert np.allclose(w0, sim.data[conn].weights)
 
     # test that weights load correctly

--- a/nengo_dl/tests/test_nengo_tests.py
+++ b/nengo_dl/tests/test_nengo_tests.py
@@ -1,14 +1,11 @@
 # pylint: disable=missing-docstring
 
-from distutils.version import LooseVersion
-
 import nengo
 from nengo.builder.signal import Signal
 from nengo.builder.operator import ElementwiseInc, DotInc
 import numpy as np
 import pkg_resources
 import pytest
-import tensorflow as tf
 
 import nengo_dl
 from nengo_dl.tests import dummies
@@ -77,9 +74,6 @@ def test_signal_init_values(Simulator):
 
 
 def test_entry_point():
-    if LooseVersion(tf.__version__) == "1.11.0":
-        pytest.xfail("TensorFlow 1.11.0 has conflicting dependencies")
-
     sims = [
         ep.load(require=False)
         for ep in pkg_resources.iter_entry_points(group="nengo.backends")

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 
 from collections import OrderedDict
-from distutils.version import LooseVersion
 import logging
 import os
 import pickle
@@ -16,6 +15,7 @@ from nengo.exceptions import (
     ValidationError,
 )
 import numpy as np
+from packaging import version
 import pytest
 import tensorflow as tf
 from tensorflow.core.util import event_pb2
@@ -806,7 +806,7 @@ def test_tensorboard(Simulator, tmpdir):
     with pytest.raises(ValidationError, match="Unknown summary object"):
         callbacks.NengoSummaries(log_dir=log_dir + "/nengo", sim=sim, objects=[a])
 
-    if LooseVersion(nengo.__version__) >= "3.1.0":
+    if version.parse(nengo.__version__) >= version.parse("3.1.0.dev0"):
         with pytest.raises(ValidationError, match="does not have any weights"):
             callbacks.NengoSummaries(log_dir=log_dir + "/nengo", sim=sim, objects=[c0])
 

--- a/nengo_dl/tests/test_utils.py
+++ b/nengo_dl/tests/test_utils.py
@@ -1,8 +1,7 @@
 # pylint: disable=missing-docstring
 
-from distutils.version import LooseVersion
-
 import numpy as np
+from packaging import version
 import tensorflow as tf
 
 from nengo_dl import utils
@@ -78,7 +77,7 @@ def test_progress_bar():
 
 
 def test_gpu_check():
-    if LooseVersion(tf.__version__) < "2.1.0":
+    if version.parse(tf.__version__) < version.parse("2.1.0rc0"):
         gpus_available = tf.config.experimental.list_physical_devices("GPU")
     else:
         gpus_available = tf.config.list_physical_devices("GPU")

--- a/nengo_dl/utils.py
+++ b/nengo_dl/utils.py
@@ -2,7 +2,6 @@
 Utility objects used throughout the code base.
 """
 
-from distutils.version import LooseVersion
 import logging
 import re
 import subprocess
@@ -12,6 +11,7 @@ import time
 
 from nengo.exceptions import SimulationError
 import numpy as np
+from packaging import version
 import progressbar
 import tensorflow as tf
 
@@ -29,7 +29,11 @@ tf_gpu_installed = not subprocess.call(
         "import sys; "
         "import tensorflow as tf; "
         "sys.exit(len(tf.config%s.list_physical_devices('GPU')) == 0)"
-        % (".experimental" if LooseVersion(tf.__version__) < "2.1.0" else ""),
+        % (
+            ".experimental"
+            if version.parse(tf.__version__) < version.parse("2.1.0rc0")
+            else ""
+        ),
     ]
 )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -153,6 +153,7 @@ known-third-party =
     numpy,
     pytest,
     PIL,
+    packaging,
     progressbar,
     tensorflow,
 max-line-length = 88


### PR DESCRIPTION
This functionality (and `Simulator.freeze_params`, which depends on it) had not been updated after the introduction of Sparse transforms.

Fixes #148