### PR TITLE
Add notes on timeseries data to Keras example

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,8 +24,10 @@ Release history
 **Fixed**
 
 - Support Sparse transforms in ``Simulator.get_nengo_params``. (`#149`_)
+- Fixed bug in TensorGraph log message when logging was enabled. (`#151`_)
 
 .. _#149: https://github.com/nengo/nengo-dl/pull/149
+.. _#151: https://github.com/nengo/nengo-dl/pull/151
 
 3.2.0 (April 2, 2020)
 ---------------------

--- a/docs/examples/keras-to-snn.ipynb
+++ b/docs/examples/keras-to-snn.ipynb
@@ -343,7 +343,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see now that while initially there's no network activity, eventually we do start getting some spikes. Note that although we start seeing spikes in the `conv0` layer around the 10th timestep, we don't start seeing activity in the output layer until around the 40th timestep. That is because each layer in the network is adding a similar delay as we see in `conv0`, so when you put those all together in series it takes time for the activity to propagate through to the final output layer."
+    "We can see now that while initially there's no network activity, eventually we do start getting some spikes. Note that although we start seeing spikes in the `conv0` layer around the 10th timestep, we don't start seeing activity in the output layer until around the 40th timestep. That is because each layer in the network is adding a similar delay as we see in `conv0`, so when you put those all together in series it takes time for the activity to propagate through to the final output layer.\n",
+    "\n",
+    "It is important to keep in mind that this issue of \"ramp up\" time is specifically because we're processing a disconnected set of discrete inputs (images), rather than a continuous stream of input data. In general, spiking neural networks are much better suited for continuous time-series data, as then the internal state of the neurons can continuously transition between inputs. But we're using discrete inputs in this example as that is more typical in Keras models."
    ]
   },
   {
@@ -385,7 +387,7 @@
    "source": [
     "We can see that adding synaptic filtering smooths the output of the model and thereby improves the accuracy. With `synapse=0.01` we're achieving ~80% test accuracy; still not great, but significantly better than what we started with.\n",
     "\n",
-    "However, increasing the magnitude of the synaptic filtering also increases the latency before we start seeing output activity. We can see that with `synapse=0.01` we don't start seeing output activity until around the 70th timestep. This means that with more synaptic filtering we have to present the input images for a longer period of time, which takes longer to simulate and adds more latency to the model's predictions. This is a common tradeoff in spiking networks (latency versus accuracy)."
+    "However, increasing the magnitude of the synaptic filtering also increases the latency before we start seeing output activity. We can see that with `synapse=0.01` we don't start seeing output activity until around the 70th timestep. This means that with more synaptic filtering we have to present the input images for a longer period of time, which takes longer to simulate and adds more latency to the model's predictions. This is a common tradeoff in spiking networks (latency versus accuracy). But note that, as mentioned above, this issue is exaggerated by the fact that we are using discrete inputs in this example, rather than a more natural (for spiking networks) continuous time-series problem."
    ]
   },
   {

--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -271,7 +271,8 @@ class Converter:
                 logger.info("Nengo:\n%s", nengo_vals[fails])
                 raise ValueError(
                     "Output of Keras model does not match output of converted "
-                    "Nengo network"
+                    "Nengo network (max difference=%.2E; set log level to INFO to see "
+                    "all failures)" % max(abs(keras_vals[fails] - nengo_vals[fails]))
                 )
 
         return True

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -174,7 +174,7 @@ class TensorGraph(tf.keras.layers.Layer):
         logger.info("Optimized plan length: %d", len(self.plan))
         logger.info(
             "Number of base arrays: (%s, %d), (%s, %d), (%s, %d)",
-            *tuple((k, len(x)) for k, x in self.base_arrays_init.items()),
+            *sum(((k, len(x)) for k, x in self.base_arrays_init.items()), ()),
         )
 
     def build_inputs(self):

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -1822,3 +1822,19 @@ def test_sim_close(Simulator):
     with pytest.raises(SimulatorClosed, match="simulator is closed"):
         with sim:
             pass
+
+
+def test_logging(Simulator, caplog):
+    with nengo.Network() as net:
+        inp = nengo.Node([0])
+        ens = nengo.Ensemble(10, 1)
+        nengo.Connection(inp, ens)
+        nengo.Probe(ens)
+
+    # run a simulation with logging to verify that there are no errors
+    with caplog.at_level(logging.NOTSET):
+        with Simulator(net) as sim:
+            sim.run_steps(10)
+
+    for rec in caplog.records:
+        assert rec.getMessage(), "Record %s has empty message" % rec


### PR DESCRIPTION
Also added a bit more information to the Converter verification failure error message, and fixed a bug in the logging messages I discovered while looking at this.