### PR TITLE
Support for recent neuron refactoring in Nengo core

### DIFF
--- a/.templates/LICENSE.rst.template
+++ b/.templates/LICENSE.rst.template
@@ -11,6 +11,8 @@ NengoDL imports several open source libraries:
   `Apache license <https://github.com/tensorflow/tensorflow/blob/master/LICENSE>`__
 * `Jinja2 <https://palletsprojects.com/p/jinja/>`_ - Used under
   `BSD license <https://palletsprojects.com/license/>`__
+* `Packaging <https://packaging.pypa.io/en/latest/>`__ - Used under
+  `BSD license <https://github.com/pypa/packaging/blob/master/LICENSE.BSD>`__
 * `Progressbar 2 <https://progressbar-2.readthedocs.io/en/latest/>`_ - Used under
   `BSD license <https://github.com/WoLpH/python-progressbar/blob/develop/LICENSE>`__
 

--- a/.templates/setup.py.template
+++ b/.templates/setup.py.template
@@ -45,6 +45,7 @@ install_req = [
     "numpy>=1.16.0",
     "%s>=2.0.0" % tf_req,
     "jinja2>=2.10.1",
+    "packaging>=20.0",
     "progressbar2>=3.39.0",
 ]
 {% endblock %}

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Release history
 **Added**
 
 - Added support for new Nengo core ``NeuronType`` state implementation. (`#159`_)
+- Compatible with TensorFlow 2.3.0. (`#159`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Release history
 
 - Added support for new Nengo core ``NeuronType`` state implementation. (`#159`_)
 - Compatible with TensorFlow 2.3.0. (`#159`_)
+- Added support for ``nengo.Tanh`` neuron type. (`#159`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,8 @@ Release history
 
 - Added support for new Nengo core ``NeuronType`` state implementation. (`#159`_)
 - Compatible with TensorFlow 2.3.0. (`#159`_)
-- Added support for ``nengo.Tanh`` neuron type. (`#159`_)
+- Added support for ``nengo.Tanh``, ``nengo.RegularSpiking``,
+  ``nengo.StochasticSpiking``, and ``nengo.PoissonSpiking`` neuron types. (`#159`_)
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,8 @@ Release history
 - Fixed bug in TensorGraph log message when logging was enabled. (`#151`_)
 - Updated the KerasWrapper class in the ``tensorflow-models`` example to fix
   a compatibility issue in TensorFlow 2.2. (`#153`_)
+- Handle Nodes that are not connected to anything else, but are probed (this only
+  occurs in Nengo>=3.1.0). (`#159`_)
 
 .. _#149: https://github.com/nengo/nengo-dl/pull/149
 .. _#151: https://github.com/nengo/nengo-dl/pull/151

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,10 @@ Release history
 3.2.1 (unreleased)
 ------------------
 
+**Added**
+
+- Added support for new Nengo core ``NeuronType`` state implementation. (`#159`_)
+
 **Changed**
 
 - ``Simulator.evaluate`` no longer prints any information to stdout in TensorFlow
@@ -38,6 +42,7 @@ Release history
 .. _#149: https://github.com/nengo/nengo-dl/pull/149
 .. _#151: https://github.com/nengo/nengo-dl/pull/151
 .. _#153: https://github.com/nengo/nengo-dl/pull/153
+.. _#159: https://github.com/nengo/nengo-dl/pull/159
 
 3.2.0 (April 2, 2020)
 ---------------------

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -35,6 +35,8 @@ NengoDL imports several open source libraries:
   `Apache license <https://github.com/tensorflow/tensorflow/blob/master/LICENSE>`__
 * `Jinja2 <https://palletsprojects.com/p/jinja/>`_ - Used under
   `BSD license <https://palletsprojects.com/license/>`__
+* `Packaging <https://packaging.pypa.io/en/latest/>`__ - Used under
+  `BSD license <https://github.com/pypa/packaging/blob/master/LICENSE.BSD>`__
 * `Progressbar 2 <https://progressbar-2.readthedocs.io/en/latest/>`_ - Used under
   `BSD license <https://github.com/WoLpH/python-progressbar/blob/develop/LICENSE>`__
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,18 @@ Installing TensorFlow
 Use ``pip install tensorflow`` to install the minimal version of TensorFlow,
 or ``pip install tensorflow-gpu`` to include GPU support.
 
-It is also possible to install TensorFlow from source.  This is significantly
+In order to use TensorFlow with GPU support you will need to install the appropriate
+Nvidia drivers and CUDA/cuDNN. The precise steps for accomplishing this will depend
+on your system. On Linux the correct Nvidia drivers (as of TensorFlow 2.2.0) can be
+installed via ``sudo apt install nvidia-drivers-430``, and on Windows simply using the
+most up-to-date drivers should work.  For CUDA/cuDNN we recommend using
+`conda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_ to
+simplify the process. ``conda install tensorflow-gpu`` will install TensorFlow as
+well as all the CUDA/cuDNN requirements.  If you run into any problems, see the
+`TensorFlow GPU installation instructions <https://www.tensorflow.org/install/gpu>`_
+for more details.
+
+It is also possible to build TensorFlow from source.  This is significantly
 more complicated but allows you to customize the installation to your
 computer, which can improve simulation speeds.
 

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -143,8 +143,9 @@ else:
 linalg_onenormest.aslinearoperator = linalg_interface.aslinearoperator
 
 if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
-    Tanh = None
-    NoTransform = type(None)
+    PoissonSpiking = RegularSpiking = StochasticSpiking = Tanh = NoTransform = type(
+        None
+    )
 
     default_transform = 1
 
@@ -166,7 +167,7 @@ if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
 
 
 else:
-    from nengo.neurons import Tanh
+    from nengo.neurons import PoissonSpiking, RegularSpiking, StochasticSpiking, Tanh
     from nengo.transforms import NoTransform
 
     default_transform = None

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -143,6 +143,7 @@ else:
 linalg_onenormest.aslinearoperator = linalg_interface.aslinearoperator
 
 if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
+    Tanh = None
     NoTransform = type(None)
 
     default_transform = 1
@@ -165,6 +166,7 @@ if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
 
 
 else:
+    from nengo.neurons import Tanh
     from nengo.transforms import NoTransform
 
     default_transform = None

--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -7,8 +7,10 @@ import warnings
 
 import nengo
 import numpy as np
+from packaging import version
 import tensorflow as tf
 from tensorflow.python.util import nest
+from tensorflow.python.keras import engine
 
 from nengo_dl import compat
 from nengo_dl.config import configure_settings
@@ -815,7 +817,11 @@ class LayerConverter:
         raise NotImplementedError("Subclasses must implement convert")
 
 
-@Converter.register(tf.keras.Model)
+@Converter.register(
+    tf.keras.Model
+    if version.parse(tf.__version__) < version.parse("2.3.0rc0")
+    else engine.functional.Functional
+)
 class ConvertModel(LayerConverter):
     """Convert ``tf.keras.Model`` to Nengo objects."""
 

--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -447,6 +447,13 @@ class LayerConverter:
         tf.keras.activations.sigmoid: nengo.Sigmoid(tau_ref=1),
         tf.nn.sigmoid: nengo.Sigmoid(tau_ref=1),
     }
+    if version.parse(nengo.__version__) > version.parse("3.0.0"):
+        activation_map.update(
+            {
+                tf.keras.activations.tanh: compat.Tanh(tau_ref=1),
+                tf.nn.tanh: compat.Tanh(tau_ref=1),
+            }
+        )
 
     # attributes of the Keras layer that are not supported for non-default values.
     # the default value is assumed to be None, or a tuple of

--- a/nengo_dl/neuron_builders.py
+++ b/nengo_dl/neuron_builders.py
@@ -235,6 +235,27 @@ class SigmoidBuilder(OpBuilder):
         signals.scatter(self.output_data, tf.nn.sigmoid(J) / self.tau_ref)
 
 
+class TanhBuilder(OpBuilder):
+    """Build a group of `~nengo.Tanh` neuron operators."""
+
+    def __init__(self, ops, signals, config):
+        super().__init__(ops, signals, config)
+
+        self.J_data = signals.combine([op.J for op in ops])
+        self.output_data = signals.combine([op.output for op in ops])
+
+        self.tau_ref = signals.op_constant(
+            [op.neurons for op in ops],
+            [op.J.shape[0] for op in ops],
+            "tau_ref",
+            signals.dtype,
+        )
+
+    def build_step(self, signals):
+        J = signals.gather(self.J_data)
+        signals.scatter(self.output_data, tf.nn.tanh(J) / self.tau_ref)
+
+
 class LIFRateBuilder(OpBuilder):
     """Build a group of `~nengo.LIFRate` neuron operators."""
 
@@ -439,6 +460,7 @@ class SimNeuronsBuilder(OpBuilder):
         LeakyReLU: RectifiedLinearBuilder,
         SpikingLeakyReLU: SpikingRectifiedLinearBuilder,
         Sigmoid: SigmoidBuilder,
+        compat.Tanh: TanhBuilder,
         LIF: LIFBuilder,
         LIFRate: LIFRateBuilder,
         SoftLIFRate: SoftLIFRateBuilder,

--- a/nengo_dl/neuron_builders.py
+++ b/nengo_dl/neuron_builders.py
@@ -121,24 +121,85 @@ class GenericNeuronBuilder(OpBuilder):
             signals.scatter(s, state_out[i])
 
 
-class RectifiedLinearBuilder(OpBuilder):
-    """Build a group of `~nengo.RectifiedLinear` neuron operators."""
+class TFNeuronBuilder(OpBuilder):
+    """Base class for `~nengo.neurons.NeuronType` builders with a TF implementation."""
+
+    # TODO: this can be delegated to op.neurons.spiking if we increase the minimum
+    #  Nengo version to one where that attribute is guaranteed to exist
+    spiking = False
 
     def __init__(self, ops, signals, config):
         super().__init__(ops, signals, config)
 
+        if hasattr(ops[0].neurons, "amplitude"):
+            if all(op.neurons.amplitude == 1 for op in ops):
+                self.amplitude = None
+            else:
+                self.amplitude = signals.op_constant(
+                    [op.neurons for op in ops],
+                    [op.J.shape[0] for op in ops],
+                    "amplitude",
+                    signals.dtype,
+                )
+        else:
+            self.amplitude = None
+        self.alpha = 1 if self.amplitude is None else self.amplitude
+        self.alpha /= signals.dt
+
         self.J_data = signals.combine([op.J for op in ops])
         self.output_data = signals.combine([op.output for op in ops])
 
-        if all(op.neurons.amplitude == 1 for op in ops):
-            self.amplitude = None
+        self.state_data = OrderedDict(
+            (state, signals.combine([compat.neuron_state(op)[state] for op in ops]))
+            for state in compat.neuron_state(ops[0])
+        )
+
+    def step(self, J, dt, **state):
+        """Implements the logic for a single inference step."""
+        raise NotImplementedError("Subclasses must implement")
+
+    def training_step(self, J, dt, **state):
+        """
+        Implements the logic for a single training step.
+
+        Note: subclasses only need to implement this if ``spiking=True``. It is used
+        to specify an alternate (differentiable) implementation of the neuron model
+        to be used during training.
+        """
+
+    def build_step(self, signals, **step_kwargs):
+        J = signals.gather(self.J_data)
+        state = OrderedDict((s, signals.gather(d)) for s, d in self.state_data.items())
+
+        step_output = tf.nest.flatten(self.step(J, signals.dt, **state))
+
+        if not self.spiking or self.config.inference_only:
+            out = step_output
         else:
-            self.amplitude = signals.op_constant(
-                [op.neurons for op in ops],
-                [op.J.shape[0] for op in ops],
-                "amplitude",
-                signals.dtype,
+            out = tf.nest.flatten(
+                tf_utils.smart_cond(
+                    self.config.training,
+                    true_fn=lambda: (self.training_step(J, signals.dt, **state),)
+                    + tuple(state.values()),
+                    # we use stop_gradient to avoid propagating any nans (those get
+                    # propagated through the cond even if the spiking version isn't
+                    # being used at all)
+                    false_fn=lambda: tuple(
+                        tf.stop_gradient(x) for x in tf.nest.flatten(step_output)
+                    ),
+                )
             )
+
+        signals.scatter(self.output_data, out[0])
+        for state_data, v in zip(self.state_data.values(), out[1:]):
+            signals.scatter(state_data, v)
+
+
+class RectifiedLinearBuilder(TFNeuronBuilder):
+    """Build a group of `~nengo.RectifiedLinear` neuron operators."""
+
+    def __init__(self, ops, signals, config):
+        super().__init__(ops, signals, config)
 
         if all(getattr(op.neurons, "negative_slope", 0) == 0 for op in ops):
             self.negative_slope = None
@@ -150,7 +211,7 @@ class RectifiedLinearBuilder(OpBuilder):
                 signals.dtype,
             )
 
-    def _step(self, J):
+    def step(self, J, dt):
         out = tf.nn.relu(J)
         if self.negative_slope is not None:
             out -= self.negative_slope * tf.nn.relu(-J)
@@ -158,26 +219,13 @@ class RectifiedLinearBuilder(OpBuilder):
             out *= self.amplitude
         return out
 
-    def build_step(self, signals):
-        J = signals.gather(self.J_data)
-        out = self._step(J)
-        signals.scatter(self.output_data, out)
-
 
 class SpikingRectifiedLinearBuilder(RectifiedLinearBuilder):
     """Build a group of `~nengo.SpikingRectifiedLinear` neuron operators."""
 
-    def __init__(self, ops, signals, config):
-        super().__init__(ops, signals, config)
+    spiking = True
 
-        self.voltage_data = signals.combine(
-            [compat.neuron_state(op)["voltage"] for op in ops]
-        )
-
-        self.alpha = 1 if self.amplitude is None else self.amplitude
-        self.alpha /= signals.dt
-
-    def _step(self, J, voltage, dt):
+    def step(self, J, dt, voltage):
         if self.negative_slope is None:
             voltage += tf.nn.relu(J) * dt
             n_spikes = tf.floor(voltage)
@@ -188,41 +236,18 @@ class SpikingRectifiedLinearBuilder(RectifiedLinearBuilder):
         voltage -= n_spikes
         out = n_spikes * self.alpha
 
-        # we use stop_gradient to avoid propagating any nans (those get
-        # propagated through the cond even if the spiking version isn't
-        # being used at all)
-        return tf.stop_gradient(out), tf.stop_gradient(voltage)
+        return out, voltage
 
-    def build_step(self, signals):
-        J = signals.gather(self.J_data)
-        voltage = signals.gather(self.voltage_data)
-
-        spike_out, spike_voltage = self._step(J, voltage, signals.dt)
-
-        if self.config.inference_only:
-            out, voltage = spike_out, spike_voltage
-        else:
-            rate_out = super()._step(J)
-
-            out, voltage = tf_utils.smart_cond(
-                self.config.training,
-                true_fn=lambda: (rate_out, voltage),
-                false_fn=lambda: (spike_out, spike_voltage),
-            )
-
-        signals.scatter(self.output_data, out)
-        signals.scatter(self.voltage_data, voltage)
+    def training_step(self, J, dt, **state):
+        return super().step(J, dt)
 
 
-class SigmoidBuilder(OpBuilder):
+class SigmoidBuilder(TFNeuronBuilder):
     """Build a group of `~nengo.Sigmoid` neuron operators."""
 
     def __init__(self, ops, signals, config):
         super().__init__(ops, signals, config)
 
-        self.J_data = signals.combine([op.J for op in ops])
-        self.output_data = signals.combine([op.output for op in ops])
-
         self.tau_ref = signals.op_constant(
             [op.neurons for op in ops],
             [op.J.shape[0] for op in ops],
@@ -230,20 +255,16 @@ class SigmoidBuilder(OpBuilder):
             signals.dtype,
         )
 
-    def build_step(self, signals):
-        J = signals.gather(self.J_data)
-        signals.scatter(self.output_data, tf.nn.sigmoid(J) / self.tau_ref)
+    def step(self, J, dt):
+        return tf.nn.sigmoid(J) / self.tau_ref
 
 
-class TanhBuilder(OpBuilder):
+class TanhBuilder(TFNeuronBuilder):
     """Build a group of `~nengo.Tanh` neuron operators."""
 
     def __init__(self, ops, signals, config):
         super().__init__(ops, signals, config)
 
-        self.J_data = signals.combine([op.J for op in ops])
-        self.output_data = signals.combine([op.output for op in ops])
-
         self.tau_ref = signals.op_constant(
             [op.neurons for op in ops],
             [op.J.shape[0] for op in ops],
@@ -251,12 +272,11 @@ class TanhBuilder(OpBuilder):
             signals.dtype,
         )
 
-    def build_step(self, signals):
-        J = signals.gather(self.J_data)
-        signals.scatter(self.output_data, tf.nn.tanh(J) / self.tau_ref)
+    def step(self, J, dt):
+        return tf.nn.tanh(J) / self.tau_ref
 
 
-class LIFRateBuilder(OpBuilder):
+class LIFRateBuilder(TFNeuronBuilder):
     """Build a group of `~nengo.LIFRate` neuron operators."""
 
     def __init__(self, ops, signals, config):
@@ -274,43 +294,30 @@ class LIFRateBuilder(OpBuilder):
             "tau_rc",
             signals.dtype,
         )
-        self.amplitude = signals.op_constant(
-            [op.neurons for op in ops],
-            [op.J.shape[0] for op in ops],
-            "amplitude",
-            signals.dtype,
-        )
 
-        self.J_data = signals.combine([op.J for op in ops])
-        self.output_data = signals.combine([op.output for op in ops])
         self.zeros = tf.zeros(
             (signals.minibatch_size,) + self.J_data.shape, signals.dtype
         )
 
         self.epsilon = tf.constant(1e-15, dtype=signals.dtype)
 
-        # copy these so that they're easily accessible in the _step functions
+        # copy these so that they're easily accessible in the step functions
         self.zero = signals.zero
         self.one = signals.one
 
-    def _step(self, j):
-        j -= self.one
+    def step(self, J, dt):
+        J -= self.one
 
         # note: we convert all the j to be positive before this calculation
         # (even though we'll only use the values that are already positive),
         # otherwise we can end up with nans in the gradient
-        rates = self.amplitude / (
+        rates = (self.one if self.amplitude is None else self.amplitude) / (
             self.tau_ref
             + self.tau_rc
-            * tf.math.log1p(tf.math.reciprocal(tf.maximum(j, self.epsilon)))
+            * tf.math.log1p(tf.math.reciprocal(tf.maximum(J, self.epsilon)))
         )
 
-        return tf.where(j > self.zero, rates, self.zeros)
-
-    def build_step(self, signals):
-        j = signals.gather(self.J_data)
-        rates = self._step(j)
-        signals.scatter(self.output_data, rates)
+        return tf.where(J > self.zero, rates, self.zeros)
 
 
 class SoftLIFRateBuilder(LIFRateBuilder):
@@ -326,7 +333,7 @@ class SoftLIFRateBuilder(LIFRateBuilder):
             signals.dtype,
         )
 
-    def _step(self, J):
+    def step(self, J, dt):
         J -= self.one
 
         js = J / self.sigma
@@ -343,20 +350,17 @@ class SoftLIFRateBuilder(LIFRateBuilder):
             j_valid, tf.math.log1p(tf.math.reciprocal(z)), -js - tf.math.log(self.sigma)
         )
 
-        rates = self.amplitude / (self.tau_ref + self.tau_rc * q)
+        rates = (self.one if self.amplitude is None else self.amplitude) / (
+            self.tau_ref + self.tau_rc * q
+        )
 
         return rates
-
-    def build_step(self, signals):
-        j = signals.gather(self.J_data)
-
-        rates = self._step(j)
-
-        signals.scatter(self.output_data, rates)
 
 
 class LIFBuilder(SoftLIFRateBuilder):
     """Build a group of `~nengo.LIF` neuron operators."""
+
+    spiking = True
 
     def __init__(self, ops, signals, config):
         # note: we skip the SoftLIFRateBuilder init
@@ -369,20 +373,12 @@ class LIFBuilder(SoftLIFRateBuilder):
             "min_voltage",
             signals.dtype,
         )
-        self.alpha = self.amplitude / signals.dt
-
-        self.voltage_data = signals.combine(
-            [compat.neuron_state(op)["voltage"] for op in ops]
-        )
-        self.refractory_data = signals.combine(
-            [compat.neuron_state(op)["refractory_time"] for op in ops]
-        )
 
         if self.config.lif_smoothing:
             self.sigma = tf.constant(self.config.lif_smoothing, dtype=signals.dtype)
 
-    def _step(self, J, voltage, refractory, dt):
-        delta_t = tf.clip_by_value(dt - refractory, self.zero, dt)
+    def step(self, J, dt, voltage, refractory_time):
+        delta_t = tf.clip_by_value(dt - refractory_time, self.zero, dt)
 
         dV = (voltage - J) * tf.math.expm1(-delta_t / self.tau_rc)
         voltage += dV
@@ -397,108 +393,28 @@ class LIFBuilder(SoftLIFRateBuilder):
         # remaining refractory period)
         # partial_ref = signals.dt * (voltage - self.one) / dV
 
-        refractory = tf.where(spiked, self.tau_ref - partial_ref, refractory - dt)
+        refractory_time = tf.where(
+            spiked, self.tau_ref - partial_ref, refractory_time - dt
+        )
 
         voltage = tf.where(spiked, self.zeros, tf.maximum(voltage, self.min_voltage))
 
-        # we use stop_gradient to avoid propagating any nans (those get
-        # propagated through the cond even if the spiking version isn't
-        # being used at all)
+        return spikes, voltage, refractory_time
+
+    def training_step(self, J, dt, **state):
         return (
-            tf.stop_gradient(spikes),
-            tf.stop_gradient(voltage),
-            tf.stop_gradient(refractory),
+            LIFRateBuilder.step(self, J, dt)
+            if self.config.lif_smoothing is None
+            else SoftLIFRateBuilder.step(self, J, dt)
         )
 
-    def build_step(self, signals):
-        J = signals.gather(self.J_data)
-        voltage = signals.gather(self.voltage_data)
-        refractory = signals.gather(self.refractory_data)
 
-        spike_out, spike_voltage, spike_ref = self._step(
-            J, voltage, refractory, signals.dt
-        )
-
-        if self.config.inference_only:
-            spikes, voltage, refractory = spike_out, spike_voltage, spike_ref
-        else:
-            rate_out = (
-                LIFRateBuilder._step(self, J)
-                if self.config.lif_smoothing is None
-                else SoftLIFRateBuilder._step(self, J)
-            )
-
-            spikes, voltage, refractory = tf_utils.smart_cond(
-                self.config.training,
-                true_fn=lambda: (rate_out, voltage, refractory),
-                false_fn=lambda: (spike_out, spike_voltage, spike_ref),
-            )
-
-        signals.scatter(self.output_data, spikes)
-        signals.scatter(self.refractory_data, refractory)
-        signals.scatter(self.voltage_data, voltage)
-
-
-class RatesToSpikesBuilder(OpBuilder):
-    """Build a group of `~nengo.neurons.RatesToSpikesNeuronType` operators."""
-
-    def __init__(self, ops, signals, config):
-        super().__init__(ops, signals, config)
-
-        if all(op.neurons.amplitude == 1 for op in ops):
-            self.amplitude = None
-        else:
-            self.amplitude = signals.op_constant(
-                [op.neurons for op in ops],
-                [op.J.shape[0] for op in ops],
-                "amplitude",
-                signals.dtype,
-            )
-        self.alpha = 1 if self.amplitude is None else self.amplitude
-        self.alpha /= signals.dt
-
-        self.J_data = signals.combine([op.J for op in ops])
-        self.output_data = signals.combine([op.output for op in ops])
-
-        self.state_data = OrderedDict(
-            (state, signals.combine([compat.neuron_state(op)[state] for op in ops]))
-            for state in compat.neuron_state(ops[0])
-        )
-
-    def build_step(self, signals, **step_kwargs):
-        J = signals.gather(self.J_data)
-
-        state = OrderedDict((s, signals.gather(d)) for s, d in self.state_data.items())
-
-        step_output = self._step(J, signals.dt, **state)
-        # we use stop_gradient to avoid propagating any nans (those get
-        # propagated through the cond even if the spiking version isn't
-        # being used at all)
-        step_output = tuple(tf.stop_gradient(x) for x in tf.nest.flatten(step_output))
-
-        if self.config.inference_only:
-            out = step_output
-        else:
-            out = tf.nest.flatten(
-                tf_utils.smart_cond(
-                    self.config.training,
-                    true_fn=lambda: (
-                        J if self.amplitude is None else J * self.amplitude,
-                    )
-                    + tuple(state.values()),
-                    false_fn=lambda: step_output,
-                )
-            )
-
-        signals.scatter(self.output_data, out[0])
-        for state_data, v in zip(self.state_data.values(), out[1:]):
-            signals.scatter(state_data, v)
-
-
-class RegularSpikingBuilder(RatesToSpikesBuilder):
+class RegularSpikingBuilder(TFNeuronBuilder):
     """Build a group of `~nengo.RegularSpiking` neuron operators."""
 
-    def _step(self, J, dt, voltage):
+    spiking = True
+
+    def step(self, J, dt, voltage):
         voltage += J * dt
         n_spikes = tf.floor(voltage)
 
@@ -507,11 +423,16 @@ class RegularSpikingBuilder(RatesToSpikesBuilder):
 
         return out, voltage
 
+    def training_step(self, J, dt, **state):
+        return J if self.amplitude is None else J * self.amplitude
 
-class StochasticSpikingBuilder(RatesToSpikesBuilder):
+
+class StochasticSpikingBuilder(TFNeuronBuilder):
     """Build a group of `~nengo.StochasticSpiking` neuron operators."""
 
-    def _step(self, J, dt):
+    spiking = True
+
+    def step(self, J, dt):
         x = dt * tf.math.abs(J)
         n_spikes = tf.floor(x)
         frac = x - n_spikes
@@ -522,11 +443,16 @@ class StochasticSpikingBuilder(RatesToSpikesBuilder):
 
         return n_spikes
 
+    def training_step(self, J, dt):
+        return J if self.amplitude is None else J * self.amplitude
 
-class PoissonSpikingBuilder(RatesToSpikesBuilder):
+
+class PoissonSpikingBuilder(TFNeuronBuilder):
     """Build a group of `~nengo.PoissonSpiking` neuron operators."""
 
-    def _step(self, J, dt):
+    spiking = True
+
+    def step(self, J, dt):
         n_spikes = (
             self.alpha
             * tf.random.poisson((), tf.math.abs(J) * dt, dtype=J.dtype)
@@ -535,6 +461,9 @@ class PoissonSpikingBuilder(RatesToSpikesBuilder):
         n_spikes.set_shape(J.shape)
 
         return n_spikes
+
+    def training_step(self, J, dt):
+        return J if self.amplitude is None else J * self.amplitude
 
 
 @Builder.register(SimNeurons)

--- a/nengo_dl/neurons.py
+++ b/nengo_dl/neurons.py
@@ -62,10 +62,10 @@ class SoftLIFRate(LIFRate):
         J = gain * x
         J += bias
         out = np.zeros_like(J)
-        self.step_math(dt=1, J=J, output=out)
+        self.step(dt=1, J=J, output=out)
         return out
 
-    def step_math(self, dt, J, output):
+    def step(self, dt, J, output):
         """Compute rates in Hz for input current (incl. bias)"""
 
         j = J - 1
@@ -76,6 +76,16 @@ class SoftLIFRate(LIFRate):
 
         q = np.where(j_valid, np.log1p(1 / z), -js - np.log(self.sigma))
         output[:] = self.amplitude / (self.tau_ref + self.tau_rc * q)
+
+    # note: need to specify these (even though they're defined in the base class)
+    # so that this works with Nengo<3.1.0 (where these attributes won't be defined)
+    # TODO: remove if we increase the minimum nengo version
+    negative = False
+    spiking = False
+
+    def step_math(self, dt, J, output):
+        """Backwards compatibility alias for ``self.step``."""
+        return self.step(dt, J, output)
 
 
 class LeakyReLU(RectifiedLinear):
@@ -91,15 +101,25 @@ class LeakyReLU(RectifiedLinear):
         multiplicatively with ``negative_slope`` for values < 0.
     """
 
-    def __init__(self, negative_slope=0.3, amplitude=1):
-        super().__init__(amplitude=amplitude)
+    def __init__(self, negative_slope=0.3, amplitude=1, **kwargs):
+        super().__init__(amplitude=amplitude, **kwargs)
 
         self.negative_slope = negative_slope
 
-    def step_math(self, dt, J, output):
+    def step(self, dt, J, output):
         """Implement the leaky relu nonlinearity."""
 
         output[...] = self.amplitude * np.where(J < 0, self.negative_slope * J, J)
+
+    # note: need to specify these (even though they're defined in the base class)
+    # so that this works with Nengo<3.1.0 (where these attributes won't be defined)
+    # TODO: remove if we increase the minimum nengo version
+    negative = False
+    spiking = False
+
+    def step_math(self, dt, J, output):
+        """Backwards compatibility alias for ``self.step``."""
+        return self.step(dt, J, output)
 
 
 class SpikingLeakyReLU(SpikingRectifiedLinear):
@@ -117,8 +137,8 @@ class SpikingLeakyReLU(SpikingRectifiedLinear):
         multiplicatively with ``negative_slope`` for values < 0.
     """
 
-    def __init__(self, negative_slope=0.3, amplitude=1):
-        super().__init__(amplitude=amplitude)
+    def __init__(self, negative_slope=0.3, amplitude=1, **kwargs):
+        super().__init__(amplitude=amplitude, **kwargs)
 
         self.negative_slope = negative_slope
 
@@ -127,15 +147,25 @@ class SpikingLeakyReLU(SpikingRectifiedLinear):
 
         J = self.current(x, gain, bias)
         out = np.zeros_like(J)
-        LeakyReLU.step_math(self, dt=1, J=J, output=out)
+        LeakyReLU.step(self, dt=1, J=J, output=out)
         return out
 
-    def step_math(self, dt, J, spiked, voltage):
+    def step(self, dt, J, output, voltage):
         """
         Implement the spiking leaky relu nonlinearity.
         """
 
         voltage += np.where(J < 0, self.negative_slope * J, J) * dt
         n_spikes = np.trunc(voltage)
-        spiked[:] = (self.amplitude / dt) * n_spikes
+        output[:] = (self.amplitude / dt) * n_spikes
         voltage -= n_spikes
+
+    # note: need to specify these (even though they're defined in the base class)
+    # so that this works with Nengo<3.1.0 (where these attributes won't be defined)
+    # TODO: remove if we increase the minimum nengo version
+    negative = False
+    spiking = True
+
+    def step_math(self, dt, J, output, voltage):
+        """Backwards compatibility alias for ``self.step``."""
+        return self.step(dt, J, output, voltage)

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -1078,7 +1078,9 @@ class TensorGraph(tf.keras.layers.Layer):
                 or (isinstance(op, TimeUpdate) and s is op.step)
                 # nengo marks neuron state as a set, but really it's more like an
                 # inc/update (since the neuron calculation may depend on the state)
-                or (isinstance(op, SimNeurons) and s in op.states)
+                or (
+                    isinstance(op, SimNeurons) and s in compat.neuron_state(op).values()
+                )
             )
 
         set_sigs = {

--- a/nengo_dl/tests/test_converter.py
+++ b/nengo_dl/tests/test_converter.py
@@ -399,7 +399,9 @@ def test_sequential(seed):
         (tf.nn.relu, nengo.LIF(), {nengo.RectifiedLinear(): nengo.LIF()}),
     ],
 )
-def test_activation_swap(Simulator, keras_activation, nengo_activation, swap, rng):
+def test_activation_swap(
+    Simulator, keras_activation, nengo_activation, swap, rng, seed
+):
     inp = x = tf.keras.Input(shape=(100,))
     x = tf.keras.layers.Activation(activation=keras_activation)(x)
     x = tf.keras.layers.Dense(
@@ -427,6 +429,10 @@ def test_activation_swap(Simulator, keras_activation, nengo_activation, swap, rn
         p = nengo.Probe(ens1.neurons)
 
     inp_vals = rng.uniform(size=(20, 50, 100))
+
+    # set the seed so that initial voltages will be the same
+    net.seed = seed
+    conv.net.seed = seed
 
     with Simulator(net) as sim0:
         data0 = sim0.predict(inp_vals)

--- a/nengo_dl/tests/test_converter.py
+++ b/nengo_dl/tests/test_converter.py
@@ -65,6 +65,10 @@ def test_activation():
     x = tf.keras.layers.Activation("sigmoid")(x)
     x = tf.keras.layers.Activation(tf.nn.sigmoid)(x)
     x = tf.keras.layers.Activation(tf.keras.activations.sigmoid)(x)
+    if version.parse(nengo.__version__) >= version.parse("3.1.0.dev0"):
+        x = tf.keras.layers.Activation("tanh")(x)
+        x = tf.keras.layers.Activation(tf.nn.tanh)(x)
+        x = tf.keras.layers.Activation(tf.keras.activations.tanh)(x)
 
     _test_convert(inp, x)
 

--- a/nengo_dl/tests/test_graph_optimizer.py
+++ b/nengo_dl/tests/test_graph_optimizer.py
@@ -1202,18 +1202,20 @@ def test_remove_reset_inc_functional(Simulator, seed):
         nengo.Connection(node0, node1, transform=np.ones((3, 1)), synapse=None)
 
         # reset+elementwiseinc (weights, in nengo<3.1)
-        # reset+copy (to probe input)
+        # reset+copy (to probe input, in nengo<3.1)
         p = nengo.Probe(node1)
 
     with Simulator(net) as sim:
-        extra_op = version.parse(nengo.__version__) < version.parse("3.1.0.dev0")
+        extra_op = (
+            2 if version.parse(nengo.__version__) < version.parse("3.1.0.dev0") else 0
+        )
 
-        assert len(sim.tensor_graph.plan) == 8 + extra_op
+        assert len(sim.tensor_graph.plan) == 7 + extra_op
 
         # check that we have all the resets we expect
         resets = sim.tensor_graph.plan[1]
         assert isinstance(resets[0], Reset)
-        assert len(resets) == 6 + extra_op
+        assert len(resets) == 5 + extra_op
 
         # check that all the ops are incs like we expect
         incs = sim.tensor_graph.plan[2:]
@@ -1235,7 +1237,7 @@ def test_remove_reset_inc_functional(Simulator, seed):
 
     with Simulator(net) as sim_remove:
         # check that resets have been removed
-        assert len(sim_remove.tensor_graph.plan) == 7 + extra_op
+        assert len(sim_remove.tensor_graph.plan) == 6 + extra_op
         assert (
             len([x for x in sim_remove.tensor_graph.plan if isinstance(x[0], Reset)])
             == 0

--- a/nengo_dl/tests/test_neurons.py
+++ b/nengo_dl/tests/test_neurons.py
@@ -2,6 +2,7 @@
 
 import nengo
 import numpy as np
+from packaging import version
 import pytest
 
 from nengo_dl import (
@@ -194,19 +195,24 @@ def test_leaky_relu(Simulator, Neurons):
         [[-0.02], [0.2]],
     )
 
+    if Neurons.spiking and version.parse(nengo.__version__) > version.parse("3.0.0"):
+        kwargs = dict(initial_state={"voltage": nengo.dists.Choice([0])})
+    else:
+        kwargs = dict()
+
     with nengo.Network() as net:
         vals = np.linspace(-400, 400, 10)
         ens0 = nengo.Ensemble(
             10,
             1,
-            neuron_type=Neurons(negative_slope=0.1, amplitude=2),
+            neuron_type=Neurons(negative_slope=0.1, amplitude=2, **kwargs),
             gain=nengo.dists.Choice([1]),
             bias=vals,
         )
         ens1 = nengo.Ensemble(
             10,
             1,
-            neuron_type=Neurons(negative_slope=0.5),
+            neuron_type=Neurons(negative_slope=0.5, **kwargs),
             gain=nengo.dists.Choice([1]),
             bias=vals,
         )

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -527,7 +527,7 @@ def test_save_load_params(Simulator, include_state, tmpdir):
 
             inp = nengo.Node([0])
             out = nengo.Node(size_in=1)
-            ens = nengo.Ensemble(10, 1)
+            ens = nengo.Ensemble(10, 1, neuron_type=dummies.DeterministicLIF())
             nengo.Connection(inp, ens)
             conn = nengo.Connection(ens, out)
             p = nengo.Probe(out)
@@ -1263,6 +1263,8 @@ def test_multiple_objective(Simulator, seed):
 
 def test_get_nengo_params(Simulator, seed):
     with nengo.Network(seed=seed) as net:
+        net.config[nengo.Ensemble].neuron_type = dummies.DeterministicLIF()
+
         a = nengo.Ensemble(12, 3, label="a")
         b = nengo.Ensemble(10, 4, label="b", radius=2)
         n = nengo.Node([1])
@@ -1308,6 +1310,8 @@ def test_get_nengo_params(Simulator, seed):
         sim.run_steps(100)
 
     with nengo.Network(seed=seed + 1) as net:
+        net.config[nengo.Ensemble].neuron_type = dummies.DeterministicLIF()
+
         a2 = nengo.Ensemble(12, 3, **params["a"])
         b2 = nengo.Ensemble(10, 4, radius=2, **params["b"])
         n2 = nengo.Node([1])

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ install_req = [
     "numpy>=1.16.0",
     "%s>=2.0.0" % tf_req,
     "jinja2>=2.10.1",
+    "packaging>=20.0",
     "progressbar2>=3.39.0",
 ]
 docs_req = [


### PR DESCRIPTION
Adds support for the NeuronType changes introduced in https://github.com/nengo/nengo/pull/1609.

Also a few unrelated fixes to get tests passing after new releases in dependencies.