### PR TITLE
Convert nested Keras models recursively

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,11 +43,13 @@ Release history
   a compatibility issue in TensorFlow 2.2. (`#153`_)
 - Handle Nodes that are not connected to anything else, but are probed (this only
   occurs in Nengo>=3.1.0). (`#159`_)
+- More robust support for converting nested Keras models in TensorFlow 2.3. (`#161`_)
 
 .. _#149: https://github.com/nengo/nengo-dl/pull/149
 .. _#151: https://github.com/nengo/nengo-dl/pull/151
 .. _#153: https://github.com/nengo/nengo-dl/pull/153
 .. _#159: https://github.com/nengo/nengo-dl/pull/159
+.. _#161: https://github.com/nengo/nengo-dl/pull/161
 
 3.2.0 (April 2, 2020)
 ---------------------

--- a/docs/converter.rst
+++ b/docs/converter.rst
@@ -140,7 +140,7 @@ As an example, here is how we might translate the ``AddOne`` layer:
             # mark the above connection as non-trainable (since we didn't have any
             # trainable parameters in the AddOne layer, we don't want any in the
             # converted Nengo equivalent either)
-            self.converter.net.config[conn].trainable = False
+            self.set_trainable(conn, False)
 
             return output
 


### PR DESCRIPTION
Instead of building the whole model as a flattened list of layers in a single network, now we build each Keras model in its own Nengo Network, and the conversion process is scoped within each Network (rather than having general data structures stored in the Converter class). 

This avoids having to trace the Keras model to create a flat list of layers, which is problematic due to relying on some relatively fragile internal Keras implementation details (e.g., it was broken in TensorFlow 2.3). This should also just be a more robust approach overall, as it is much easier in Keras to extract the list of layers within a given Keras model, rather than having to figure out how all the models are connected to one another.

Note: based on #159, as there are some general fixes there