### PR TITLE
Add support for sliced signal probes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,12 +44,15 @@ Release history
 - Handle Nodes that are not connected to anything else, but are probed (this only
   occurs in Nengo>=3.1.0). (`#159`_)
 - More robust support for converting nested Keras models in TensorFlow 2.3. (`#161`_)
+- Fix bug when probing slices of certain probeable attributes (those that are
+  directly targeting a Signal in the model). (`#164`_)
 
 .. _#149: https://github.com/nengo/nengo-dl/pull/149
 .. _#151: https://github.com/nengo/nengo-dl/pull/151
 .. _#153: https://github.com/nengo/nengo-dl/pull/153
 .. _#159: https://github.com/nengo/nengo-dl/pull/159
 .. _#161: https://github.com/nengo/nengo-dl/pull/161
+.. _#164: https://github.com/nengo/nengo-dl/pull/164
 
 3.2.0 (April 2, 2020)
 ---------------------

--- a/nengo_dl/tests/dummies.py
+++ b/nengo_dl/tests/dummies.py
@@ -179,6 +179,8 @@ class TensorGraph(tensor_graph.TensorGraph):
         self.plan = plan
         self.minibatch_size = minibatch_size
         self.seed = 0
+        self.model = nengo.builder.Model()
+        self.invariant_inputs = {}
 
         self.signals = signals.SignalDict(self.dtype, self.minibatch_size)
 


### PR DESCRIPTION
I don't think sliced signal probes have ever been working, but this omission was just revealed by the new tests in Nengo core.