### PR TITLE
Update to support core SimPES changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Release history
   in a Simulator method outside the ``with Simulator`` context. (`#173`_)
 - Support new LinearFilter step type introduced in Nengo core (see
   `#1629 <https://github.com/nengo/nengo/pull/1629>`__). (`#173`_)
+- Fixed a bug when slicing multi-dimensional Signals (e.g. Ensemble encoders).
+  (`#181`_)
 
 .. _#173: https://github.com/nengo/nengo-dl/pull/173
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ Release history
 
 - Minor improvements to build speed by building constants outside of TensorFlow.
   (`#173`_)
+- Support for PES implementation changes in Nengo core (see
+  `#1627 <https://github.com/nengo/nengo/pull/1627>`__ and
+  `#1640 <https://github.com/nengo/nengo/pull/1640>`__). (`#181`_)
 
 **Fixed**
 
@@ -36,6 +39,7 @@ Release history
   (`#181`_)
 
 .. _#173: https://github.com/nengo/nengo-dl/pull/173
+.. _#181: https://github.com/nengo/nengo-dl/pull/181
 
 3.3.0 (August 14, 2020)
 -----------------------

--- a/docs/examples/keras-to-snn.ipynb
+++ b/docs/examples/keras-to-snn.ipynb
@@ -137,9 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "converter = nengo_dl.Converter(model)"
@@ -209,9 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def run_network(\n",
@@ -310,9 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "run_network(activation=nengo.RectifiedLinear(), n_steps=10)"
@@ -341,9 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "run_network(activation=nengo.SpikingRectifiedLinear(), n_steps=10)"
@@ -378,9 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "run_network(\n",
@@ -442,9 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for s in [0.001, 0.005, 0.01]:\n",
@@ -500,9 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "for scale in [2, 10, 20]:\n",

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -200,6 +200,14 @@ if version.parse(nengo.__version__) < version.parse("3.1.0.dev0"):
         """Call step_math instead of step."""
         neuron_op.neurons.step_math(dt, J, output, *state.values())
 
+    def to_neurons(conn):
+        """Check whether the output of a connection is a neuron object."""
+        return isinstance(conn.post_obj, nengo.ensemble.Neurons) or (
+            isinstance(conn.pre_obj, nengo.Ensemble)
+            and isinstance(conn.post_obj, nengo.Ensemble)
+            and conn.solver.weights
+        )
+
 
 else:
     from nengo.neurons import PoissonSpiking, RegularSpiking, StochasticSpiking, Tanh
@@ -218,6 +226,10 @@ else:
     def neuron_step(neuron_op, dt, J, output, state):  # pragma: no cover (runs in TF)
         """Equivalent to neuron_op.step."""
         neuron_op.neurons.step(dt, J, output, **state)
+
+    def to_neurons(conn):
+        """Equivalent to conn._to_neurons."""
+        return conn._to_neurons
 
 
 def eager_enabled():

--- a/nengo_dl/tensor_graph.py
+++ b/nengo_dl/tensor_graph.py
@@ -1230,16 +1230,18 @@ class TensorGraph(tf.keras.layers.Layer):
                 # reshape view
                 self.signals[sig] = self.signals[sig.base].reshape(sig.shape)
             else:
+                # slice view
+
                 if sig.shape[1:] != sig.base.shape[1:]:
                     # TODO: support this?
                     raise NotImplementedError("Slicing on axes > 0 is not supported")
 
-                # slice view
-                assert np.all([x == 1 for x in sig.elemstrides[1:]])
-
-                start = sig.elemoffset
-                stride = sig.elemstrides[0]
-                stop = start + sig.size * stride
+                # compute slice along first dimension (dividing the element-wise strides
+                # by the size of each row)
+                row_size = np.prod(sig.shape[1:], dtype=np.int32)
+                start = sig.elemoffset // row_size
+                stride = sig.elemstrides[0] // row_size
+                stop = start + sig.shape[0] * stride
                 if stop < 0:
                     stop = None
 


### PR DESCRIPTION
Raise an error if advanced indexing is used, and fix the same bug found in nengo core (when applying PES learning on a neuron-to-neuron connection with a post slice).