### PR TITLE
Convolution transpose

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -80,6 +80,7 @@ setup_cfg:
       - tests/test_synapses.py::test_alpha atol=5e-5
       - tests/test_synapses.py::test_linearfilter atol=1e-4
       - tests/test_transforms.py::test_convolution[* atol=1e-6
+      - tests/test_transforms_conv.py::test_convolution[* atol=1e-4
   pylint:
     known_third_party:
       - PIL

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b0
+    rev: 21.12b0
     hooks:
     - id: black
       files: \.py$

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,12 @@ Release history
 
 *Compatible with TensorFlow 2.2.0 - 2.7.0*
 
+**Added**
+
+- Added support for ``nengo.transforms.ConvolutionTranspose``. (`#183`_)
+
+.. _#183: https://github.com/nengo/nengo-dl/pull/183
+
 3.4.3 (November 9, 2021)
 ------------------------
 

--- a/nengo_dl/graph_optimizer.py
+++ b/nengo_dl/graph_optimizer.py
@@ -26,6 +26,7 @@ from nengo_dl import (
     tensor_node,
     transform_builders,
 )
+from nengo_dl.compat import ConvTransposeInc
 
 logger = logging.getLogger(__name__)
 
@@ -1105,7 +1106,7 @@ def remove_zero_incs(operators):
 
     new_operators = []
     for op in operators:
-        if isinstance(op, (DotInc, ElementwiseInc, Copy, ConvInc)):
+        if isinstance(op, (DotInc, ElementwiseInc, Copy, ConvInc, ConvTransposeInc)):
             for src in op.reads:
                 # check if the input is the output of a Node (in which case the
                 # value might change, so we should never get rid of this op).
@@ -1179,6 +1180,7 @@ def remove_reset_incs(operators):
         Copy,
         SimProcess,
         ConvInc,
+        ConvTransposeInc,
         op_builders.ResetInc,
     ]
     incs = defaultdict(list)
@@ -1237,6 +1239,10 @@ def remove_reset_incs(operators):
                 )
             elif isinstance(incer, ConvInc):
                 setter = transform_builders.ConvSet(
+                    incer.W, incer.X, incer.Y, incer.conv, tag=incer.tag
+                )
+            elif isinstance(incer, ConvTransposeInc):
+                setter = transform_builders.ConvTransposeSet(
                     incer.W, incer.X, incer.Y, incer.conv, tag=incer.tag
                 )
             elif isinstance(incer, op_builders.ResetInc):

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,6 +109,7 @@ allclose_tolerances =
     tests/test_synapses.py::test_alpha atol=5e-5
     tests/test_synapses.py::test_linearfilter atol=1e-4
     tests/test_transforms.py::test_convolution[* atol=1e-6
+    tests/test_transforms_conv.py::test_convolution[* atol=1e-4
 
 [pylint]
 


### PR DESCRIPTION
Support the ConvTransposeInc operator added in nengo/nengo#1648.

Things might be a bit cleaner if we support `GeneralConvInc` instead of `ConvInc` and `ConvTransposeInc` (then e.g. we could have one `GeneralConvSet` operator), but some code (e.g. operator merging) breaks if we don't have build methods for each operator class (if we try to do them only for a superclass).

TODO:
- [x] Test merging ConvTransposeInc