### PR TITLE
Update CUDA versions for TF2.4

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -199,7 +199,7 @@ ci_scripts:
       NENGO_VERSION: $NENGO_VERSION
       SCIPY_VERSION: $SCIPY_VERSION
     remote_setup:
-      - conda install -y cudatoolkit=10.1 cudnn
+      - conda install -y -c nvidia cudatoolkit=10.1 cudnn=7.6
   - template: remote-script
     remote_script: docs
     output_name: remote-docs
@@ -213,7 +213,7 @@ ci_scripts:
       NENGO_VERSION: $NENGO_VERSION
       SCIPY_VERSION: $SCIPY_VERSION
     remote_setup:
-      - conda install -y cudatoolkit=10.1 cudnn
+      - conda install -y -c nvidia cudatoolkit=11.0 cudnn=8.0
   - template: remote-script
     remote_script: examples
     output_name: remote-examples
@@ -227,7 +227,7 @@ ci_scripts:
       NENGO_VERSION: $NENGO_VERSION
       SCIPY_VERSION: $SCIPY_VERSION
     remote_setup:
-      - conda install -y cudatoolkit=10.1 cudnn
+      - conda install -y -c nvidia cudatoolkit=11.0 cudnn=8.0
   - template: deploy
 
 travis_yml:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,8 +38,8 @@ is included in this package as of version 2.1.0.
 
 In order to use TensorFlow with GPU support you will need to install the appropriate
 Nvidia drivers and CUDA/cuDNN. The precise steps for accomplishing this will depend
-on your system. On Linux the correct Nvidia drivers (as of TensorFlow 2.2.0) can be
-installed via ``sudo apt install nvidia-driver-440``, and on Windows simply using the
+on your system. On Linux the correct Nvidia drivers (as of TensorFlow 2.4.0) can be
+installed via ``sudo apt install nvidia-driver-450``, and on Windows simply using the
 most up-to-date drivers should work.  For CUDA/cuDNN we recommend using
 `conda <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_ to
 simplify the process. ``conda install tensorflow-gpu`` will install TensorFlow as

--- a/nengo_dl/tests/test_keras.py
+++ b/nengo_dl/tests/test_keras.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 import tensorflow as tf
 from nengo.exceptions import BuildError, ValidationError
+from packaging import version
 
 from nengo_dl import compat, config, dists
 from nengo_dl.tests import dummies
@@ -316,12 +317,17 @@ def test_fit(Simulator, seed):
 
 
 @pytest.mark.training
-def test_learning_phase(Simulator):
-    with nengo.Network() as net:
-        inp = nengo.Node([0])
-        ens = nengo.Ensemble(
-            1, 1, gain=[0], bias=[1], neuron_type=nengo.SpikingRectifiedLinear()
+def test_learning_phase(Simulator, seed):
+    if version.parse(nengo.__version__) < version.parse("3.1.0"):
+        neuron_type = nengo.SpikingRectifiedLinear()
+    else:
+        neuron_type = nengo.SpikingRectifiedLinear(
+            initial_state={"voltage": nengo.dists.Choice([0])}
         )
+
+    with nengo.Network(seed=seed) as net:
+        inp = nengo.Node([0])
+        ens = nengo.Ensemble(1, 1, gain=[0], bias=[1], neuron_type=neuron_type)
         nengo.Connection(inp, ens, synapse=None)
         p = nengo.Probe(ens.neurons)
 


### PR DESCRIPTION
TF 2.4 uses CUDA 11.0 and CUDNN 8.0, so we need to switch to installing those in the builds using TF 2.4.