### PR TITLE
Add error for neuron builder step return length

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,12 +25,18 @@ Release history
 
 *Compatible with TensorFlow 2.2.0 - 2.4.0*
 
+**Fixed**
+
+- A more informative error message will be raised if a custom neuron build function
+  returns the wrong number of values. (`#199`_)
+
 **Removed**
 
 - Dropped support for Python 3.5 (which reached its end of life in September 2020).
   (`#184`_)
 
 .. _#184: https://github.com/nengo/nengo-dl/pull/184
+.. _#199: https://github.com/nengo/nengo-dl/pull/199
 
 3.4.0 (November 26, 2020)
 -------------------------


### PR DESCRIPTION
If the neuron builder ``step`` function does not return the correct
number of states, raise a clear error. Previously, this would fail
on a cryptic error in TF < 2.4, or fail silently in TF >= 2.4.

Addresses #198.