### PR TITLE
Use TensorFlow 2.3 for remote tests

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -244,7 +244,7 @@ travis_yml:
     - script: remote-test
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]
-        TF_VERSION: tensorflow<2.3.0
+        TF_VERSION: tensorflow==2.3.0
     - script: test-coverage
       env:
         NENGO_VERSION: git+https://github.com/nengo/nengo.git#egg=nengo[tests]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,5 +13,5 @@ repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.6.4
     hooks:
-      - id: isort
-        files: \.py$
+    - id: isort
+      files: \.py$

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
   -
     env:
       NENGO_VERSION="git+https://github.com/nengo/nengo.git#egg=nengo[tests]"
-      TF_VERSION="tensorflow<2.3.0"
+      TF_VERSION="tensorflow==2.3.0"
       SCRIPT="remote-test"
   -
     env:

--- a/nengo_dl/benchmarks.py
+++ b/nengo_dl/benchmarks.py
@@ -619,23 +619,21 @@ def run_profile(
     do_profile : bool
         Whether or not to run profiling
     reps : int
-        Repeat the run this many times (only profile data from the last
-        run will be kept).
+        Repeat the run this many times. The execution time from each run is returned,
+        but only profile data from the last run will be kept (if ``do_profile``).
     dtype : str
         Simulation dtype (e.g. "float32")
 
     Returns
     -------
-    exec_time : float
-        Time (in seconds) taken to run the benchmark, taking the minimum over
-        ``reps``.
+    exec_times : ndarray of float
+        Time (in seconds) taken to run the benchmark for each repetition.
 
     Notes
     -----
     kwargs will be passed on to `.Simulator`
     """
 
-    exec_time = 1e10
     n_batches = 1
 
     with net:
@@ -660,6 +658,7 @@ def run_profile(
         else:
             x = None
 
+        exec_times = []
         if train:
             y = {
                 net.p: np.random.randn(
@@ -679,7 +678,7 @@ def run_profile(
                     tf.profiler.experimental.start("profile")
                 start = timeit.default_timer()
                 sim.fit(x, y, epochs=1, n_steps=n_steps)
-                exec_time = min(timeit.default_timer() - start, exec_time)
+                exec_times.append(timeit.default_timer() - start)
                 if do_profile:
                     tf.profiler.experimental.stop()
 
@@ -694,15 +693,16 @@ def run_profile(
                     tf.profiler.experimental.start("profile")
                 start = timeit.default_timer()
                 sim.predict(x, n_steps=n_steps)
-                exec_time = min(timeit.default_timer() - start, exec_time)
+                exec_times.append(timeit.default_timer() - start)
                 if do_profile:
                     tf.profiler.experimental.stop()
 
-    exec_time /= n_batches
+    exec_times = np.array(exec_times)
+    exec_times /= n_batches
 
-    print("Execution time:", exec_time)
+    print(f"Execution time (min over {reps} reps): {exec_times.min()}")
 
-    return exec_time
+    return exec_times
 
 
 @click.group(chain=True)
@@ -785,7 +785,7 @@ def profile(obj, train, n_steps, batch_size, device, unroll, time_only):
     if "net" not in obj:
         raise ValueError("Must call `build` before `profile`")
 
-    obj["time"] = run_profile(
+    exec_times = run_profile(
         obj["net"],
         do_profile=not time_only,
         train=train,
@@ -794,6 +794,7 @@ def profile(obj, train, n_steps, batch_size, device, unroll, time_only):
         device=device,
         unroll_simulation=unroll,
     )
+    obj["time"] = exec_times.item()
 
 
 if __name__ == "__main__":

--- a/nengo_dl/tests/test_benchmarks.py
+++ b/nengo_dl/tests/test_benchmarks.py
@@ -238,7 +238,7 @@ def test_lmu(Simulator, native_nengo, pytestconfig):
         (benchmarks.lmu(1000, 1, native_nengo=True), True, 100, False, 1.05, 1.25),
     ],
 )
-def test_performance(net, train, minibatch_size, eager, min, max):
+def test_performance(net, train, minibatch_size, eager, min, max, capsys):
     # performance is based on Azure NC6 VM
     # CPU: Intel Xeon E5-2690 v3 @ 2.60Ghz
     # GPU: Nvidia Tesla K80
@@ -251,7 +251,7 @@ def test_performance(net, train, minibatch_size, eager, min, max):
         tf.compat.v1.disable_eager_execution()
         tf.compat.v1.disable_control_flow_v2()
 
-    time = benchmarks.run_profile(
+    times = benchmarks.run_profile(
         net,
         minibatch_size=minibatch_size,
         train=train,
@@ -261,5 +261,14 @@ def test_performance(net, train, minibatch_size, eager, min, max):
         do_profile=False,
         reps=15,
     )
+
+    with capsys.disabled():
+        print(
+            f"\nExecution times ({len(times)}): "
+            f"{times.min():.3f} (min), {times.max():.3f} (max), "
+            f"{times.mean():.3f} (mean), {times.std():.3f} (std)"
+        )
+
+    time = times.min()
     assert time > min
     assert time < max

--- a/nengo_dl/tests/test_benchmarks.py
+++ b/nengo_dl/tests/test_benchmarks.py
@@ -207,9 +207,9 @@ def test_lmu(Simulator, native_nengo, pytestconfig):
             64,
             True,
             1.0,
-            1.15,
+            1.2,
         ),
-        (benchmarks.cconv(128, 64, nengo.LIF()), False, 64, True, 2.25, 2.55),
+        (benchmarks.cconv(128, 64, nengo.LIF()), False, 64, True, 2.3, 2.6),
         (
             benchmarks.integrator(128, 32, nengo.RectifiedLinear()),
             True,
@@ -231,11 +231,11 @@ def test_lmu(Simulator, native_nengo, pytestconfig):
             False,
             None,
             True,
-            0.5,
-            0.7,
+            0.6,
+            0.8,
         ),
         (benchmarks.lmu(1000, 1, native_nengo=True), True, 100, True, 1.25, 1.45),
-        (benchmarks.lmu(1000, 1, native_nengo=True), True, 100, False, 1.05, 1.25),
+        (benchmarks.lmu(1000, 1, native_nengo=True), True, 100, False, 1.15, 1.35),
     ],
 )
 def test_performance(net, train, minibatch_size, eager, min, max, capsys):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 requires = ["setuptools", "wheel"]
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36']
 exclude = '''
 (
     '*/whitepaper2018_code.py'


### PR DESCRIPTION
This causes a regression in two benchmark tests:
- net4: Random network with RectifiedLinear neurons
- net6: LMU with eager mode off

Two other benchmarks are adjusted slightly to re-center them on the
times currently achieved under TensorFlow 2.2.

Here are the full results before this commit:

nengo_dl/tests/test_benchmarks.py::test_performance[net0-False-64-True-1.0-1.15]
  Execution times (15): 1.092 (min), 1.146 (max), 1.122 (mean), 0.016 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net1-False-64-True-2.25-2.55]
  Execution times (15): 2.468 (min), 2.507 (max), 2.488 (mean), 0.014 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net2-True-64-True-0.6-0.9]
  Execution times (15): 0.793 (min), 0.842 (max), 0.812 (mean), 0.015 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net3-True-64-True-0.95-1.15]
  Execution times (15): 1.034 (min), 1.082 (max), 1.057 (mean), 0.013 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net4-False-None-True-0.5-0.7]
  Execution times (15): 0.647 (min), 0.656 (max), 0.649 (mean), 0.002 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net5-True-100-True-1.25-1.45]
  Execution times (15): 1.345 (min), 1.399 (max), 1.367 (mean), 0.015 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net6-True-100-False-1.05-1.25]
  Execution times (15): 1.180 (min), 1.197 (max), 1.186 (mean), 0.005 (std)

Here are the full results after this commit:

nengo_dl/tests/test_benchmarks.py::test_performance[net0-False-64-True-1.0-1.15]
  Execution times (15): 1.109 (min), 1.186 (max), 1.134 (mean), 0.020 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net1-False-64-True-2.25-2.55]
  Execution times (15): 2.488 (min), 2.539 (max), 2.509 (mean), 0.015 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net2-True-64-True-0.6-0.9]
  Execution times (15): 0.684 (min), 0.728 (max), 0.700 (mean), 0.013 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net3-True-64-True-0.95-1.15]
  Execution times (15): 1.023 (min), 1.064 (max), 1.040 (mean), 0.011 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net4-False-None-True-0.5-0.7]
  Execution times (15): 0.700 (min), 0.717 (max), 0.705 (mean), 0.004 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net5-True-100-True-1.25-1.45]
  Execution times (15): 1.326 (min), 1.357 (max), 1.339 (mean), 0.009 (std)
nengo_dl/tests/test_benchmarks.py::test_performance[net6-True-100-False-1.05-1.25]
  Execution times (15): 1.237 (min), 1.262 (max), 1.245 (mean), 0.006 (std)