### PR TITLE
Increase minimum keras-spiking version to 0.3

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -285,7 +285,7 @@ codecov_yml:
 setup_py:
   include_package_data: True
   optional_req:
-    - keras-spiking>=0.2.0
+    - keras-spiking>=0.3.0
   docs_req:
     - click>=6.7  # needed for sphinx-click
     - jupyter>=1.0.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,12 @@ Release history
 
 - Added support for TensorFlow 2.7.0. (`#218`_)
 
+**Changed**
+
+- Increased minimum ``keras-spiking`` version to 0.3.0. (`#219`_)
+
 .. _#218: https://github.com/nengo/nengo-dl/pull/218
+.. _#219: https://github.com/nengo/nengo-dl/pull/219
 
 3.4.2 (August 12, 2021)
 -----------------------

--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -1738,7 +1738,7 @@ class ConvertLowpassAlpha(ConvertKerasSpiking):
 
         output = self.add_nengo_obj(node_id)
 
-        tau = np.ravel(tf.keras.backend.get_value(self.layer.layer.cell.tau_var))[0]
+        tau = np.ravel(tf.keras.backend.get_value(self.layer.layer.cell.tau))[0]
 
         synapse = (
             nengo.Lowpass(tau)
@@ -1769,7 +1769,7 @@ class ConvertLowpassAlpha(ConvertKerasSpiking):
             )
             return False, msg
 
-        tau = tf.keras.backend.get_value(layer.layer.cell.tau_var)
+        tau = tf.keras.backend.get_value(layer.layer.cell.tau)
         if not np.allclose(tau, np.ravel(tau)[0]):
             msg = (
                 f"Cannot convert a {type(layer).__name__} layer to native Nengo "

--- a/nengo_dl/tests/test_converter.py
+++ b/nengo_dl/tests/test_converter.py
@@ -928,7 +928,7 @@ def test_lowpass_alpha(Layer, tau, dt, Simulator, rng):
 
     inp = x = tf.keras.Input((None, 10))
     x = tf.keras.layers.Dense(units=10)(x)
-    x = Layer(tau=tau, dt=dt, trainable=False)(x)
+    x = Layer(tau_initializer=tau, dt=dt, trainable=False)(x)
 
     model = tf.keras.Model(inp, x)
 
@@ -976,7 +976,7 @@ def test_lowpass_alpha(Layer, tau, dt, Simulator, rng):
 
     # can't convert trainable layers
     inp = tf.keras.Input((None, 10))
-    layer = Layer(tau=0.1, trainable=True)
+    layer = Layer(tau_initializer=0.1, trainable=True)
     model = tf.keras.Model(inp, layer(inp))
     with pytest.raises(TypeError, match="layer.trainable=False"):
         converter.Converter(model, temporal_model=True)
@@ -995,7 +995,7 @@ def test_lowpass_alpha(Layer, tau, dt, Simulator, rng):
         layer.layer.cell.initial_level, np.zeros(layer.layer.cell.initial_level.shape)
     )
     tf.keras.backend.set_value(
-        layer.layer.cell.tau_var, np.arange(10).reshape(layer.layer.cell.tau_var.shape)
+        layer.layer.cell.tau, np.arange(10).reshape(layer.layer.cell.tau.shape)
     )
     model = tf.keras.Model(inp, layer(inp))
     with pytest.raises(TypeError, match="different tau values"):

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ docs_req = [
     "sphinx-click>=1.4.1",
 ]
 optional_req = [
-    "keras-spiking>=0.2.0",
+    "keras-spiking>=0.3.0",
 ]
 tests_req = [
     "click>=6.7",


### PR DESCRIPTION
I don't think it's worth trying to be backwards compatible here, since it's an optional dependency.