### PR TITLE
Added groups param to convolutions

### DIFF
--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -209,7 +209,7 @@ ci_scripts:
       NENGO_VERSION: $NENGO_VERSION
       SCIPY_VERSION: $SCIPY_VERSION
     remote_setup:
-      - conda install -y -q -c conda-forge --override-channels "$TF_VERSION"
+      - micromamba install -y "$TF_VERSION"
   - template: remote-script
     remote_script: docs
     output_name: remote-docs
@@ -222,7 +222,7 @@ ci_scripts:
       NENGO_VERSION: $NENGO_VERSION
       SCIPY_VERSION: $SCIPY_VERSION
     remote_setup:
-      - conda install -y -q -c conda-forge --override-channels "$TF_VERSION"
+      - micromamba install -y "$TF_VERSION"
   - template: remote-script
     remote_script: examples
     output_name: remote-examples
@@ -235,7 +235,7 @@ ci_scripts:
       NENGO_VERSION: $NENGO_VERSION
       SCIPY_VERSION: $SCIPY_VERSION
     remote_setup:
-      - conda install -y -q -c conda-forge --override-channels "$TF_VERSION"
+      - micromamba install -y "$TF_VERSION"
   - template: deploy
 
 setup_py:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Release history
 
 - Included ``tensorflow-macos`` in the alternative tensorflow package names checked
   during installation. (`#228`_)
+- Added support for ``groups`` parameter to ConvertConv. (`#223`_)
 
 **Changed**
 
@@ -48,6 +49,7 @@ Release history
   incompatible ``protobuf`` version that the user will need to manually correct).
   (`#228`_)
 
+.. _#223: https://github.com/nengo/nengo-dl/pull/223
 .. _#228: https://github.com/nengo/nengo-dl/pull/228
 .. _#229: https://github.com/nengo/nengo-dl/pull/229
 

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -126,6 +126,7 @@ else:
 
 # Nengo compatibility
 
+HAS_NENGO_3_2_1 = version.parse(nengo.__version__) >= version.parse("3.2.1")
 HAS_NENGO_3_2_0 = version.parse(nengo.__version__) >= version.parse("3.2.0")
 HAS_NENGO_3_1_0 = version.parse(nengo.__version__) >= version.parse("3.1.0")
 

--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -1323,11 +1323,19 @@ class ConvertConv(LayerConverter):
             padding=self.layer.padding,
             channels_last=self.layer.data_format == "channels_last",
             init=kernel,
+            **(dict(groups=self.layer.groups) if compat.HAS_NENGO_3_2_1 else {}),
         )
 
         self.add_connection(node_id, output, transform=transform, trainable=True)
 
         return output
+
+    @classmethod
+    def convertible(cls, layer, converter):
+        if not compat.HAS_NENGO_3_2_1 and layer.groups != 1:
+            return False, "Grouped Convolution layers require Nengo>3.2.0"
+
+        return super().convertible(layer, converter)
 
 
 @Converter.register(tf.keras.layers.Conv1D)

--- a/nengo_dl/tests/test_converter.py
+++ b/nengo_dl/tests/test_converter.py
@@ -54,6 +54,26 @@ def test_conv(seed):
     _test_convert(inp, x)
 
 
+def test_conv_groups(seed):
+    tf.random.set_seed(seed)
+
+    inp = x = tf.keras.Input(shape=(28, 28, 4))
+    x = tf.keras.layers.Conv2D(filters=4, kernel_size=3, groups=4)(x)
+
+    model = tf.keras.Model(inp, x)
+
+    with contextlib.suppress() if compat.HAS_NENGO_3_2_1 else pytest.raises(
+        TypeError, match="Convolution layers require Nengo>3.2.0"
+    ):
+        conv = converter.Converter(model, allow_fallback=False)
+
+        assert conv.verify(training=False)
+        if utils.tf_gpu_installed:
+            # there are some weird bugs in TF when running backprop with grouped
+            # convolutions on the CPU
+            assert conv.verify(training=True)
+
+
 def test_activation():
     inp = x = tf.keras.Input(shape=(4,))
     x = tf.keras.layers.Activation("relu")(x)


### PR DESCRIPTION
Motivation and context:
There is a (tentatively) accepted pull request for adding[ grouped convolutions to nengo](https://github.com/nengo/nengo/tree/convolution-groups-ci) already. Before adding grouped convolutions to nengo-loihi it is neccessary to add grouped convolutions to nengo-dl.

Related Forum Posts
https://forum.nengo.ai/t/adding-a-groups-parameter-for-convolutions-in-nengo-loihi/2035/2
https://forum.nengo.ai/t/trying-to-understand-nengo-transforms-convolution/1844/4?u=mjurado3

Interactions with other PRs:
This change is dependent upon this pull requrest in the nengo repository: https://github.com/nengo/nengo/pull/1684

How has this been tested?
This is tested through the test_conv in nengo_dl/tests/test_converter.py

How long should this take to review?
30 minutes if there are no additional features that should be added. 

Where should a reviewer start?
1. First the reviewer should look at ConvIncBuilder and convince themselves that no change is needed in this function for adding grouped convolutions. I was somewhat surprised when the unit tests passed but then I realized that tf.nn.convolution  infers the groups parameter from the shape of the weights as shown in [this example](https://user-images.githubusercontent.com/18356610/159178443-52d29561-5935-495b-a8f9-3bdb92b82153.png)
2. Then the reviewer should verify that test_conv in nengo_dl/tests/test_converter.py provides sufficient coverage.

Types of changes:
New-Feature: High Level addition of groups parameter to ConvertConv

Checklist:

- [x]  I have read the CONTRIBUTING.rst document.
- [x]  I have updated the documentation accordingly.
- [x]  I have included a changelog entry.
- [x] I have added tests to cover my changes.
- [x] I have run the test suite locally and all tests passed.
