### PR TITLE
Installation detects tensorflow-macos installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ else:
         "tf-nightly-cpu",
         "tensorflow-gpu",
         "tensorflow-cpu",
+        "tensorflow-macos",
     ]:
         if d in installed_dists:
             tf_req = d


### PR DESCRIPTION
TensorFlow supports Apple silicon chips by a dedicated tensorflow package named "tensorflow-macos".

When trying to install nengo-dl, the setup doesn't detect the already installed tensorflow package as it's just checking for "tensorflow", "tensorflow-gpu", etc.