### PR TITLE
TypeError fixes in converter.py->ConvertConcatenate

### DIFF
--- a/nengo_dl/converter.py
+++ b/nengo_dl/converter.py
@@ -1239,7 +1239,8 @@ class ConvertConcatenate(LayerConverter):
         offsets = np.cumsum([shape[axis] if type(shape) is tuple else shape for shape in self.input_shape(node_id)])
         offsets = np.concatenate(([0], offsets))
 
-        for i in range(len(self.layer.input.shape)):
+        num_layers = len(self.layer.input) if type(self.layer.input) is list else 1
+        for i in range(num_layers):
             slices[axis] = slice(offsets[i], offsets[i + 1])
             self.add_connection(
                 node_id, output[np.ravel(idxs[tuple(slices)])], input_idx=i


### PR DESCRIPTION
I wanted to convert a Keras model using the nengo_dl Converter class as proposed in the docu: 
https://www.nengo.ai/nengo-dl/examples/keras-to-snn.html#Converting-a-Keras-model-to-a-Nengo-network

Thereby, I ran into two bugs so far. The issue seems to be, that nengo_dl Converter is not prepared for a Concatenate layer to get a list of length 1 as input. Here is my approach to fix it. 

1. _self.input_shape_ in ConvertConcatenate returns EITHER a list of tuples OR **just a tuple**, though the _convert_ function in ConvertConcatenate assumes that what is returned is always a **list** of tuples. Therefore, in specific cases as in mine you get a TypeError.

2. If I get it right, this _for loop_ at line 1242 assumes _self.layer.input_ to always be a list of KerasTensors. Though, if the Concatenate layer gets only one KerasTensor as input, _self.layer.input_ is not a list but just that KerasTensor. Keras layers work on symbolic inputs/outputs meaning their "KerasTensor" do not hold actual data and therefore do not implement functions like "_\_\_len___". That is why in that case we gete a _TypeError_ as well.