### PR TITLE
Installation detects tensorflow-macos installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
     inputs:
       debug_enabled:
         description: Run the build with SSH debugging enabled
+        type: boolean
         required: false
         default: false
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             coverage-name: oldest
             python: "3.7"
             numpy-version: numpy==1.16.0
-            tf-version: tensorflow==2.2.0
+            tf-version: tensorflow==2.3.4
             nengo-version: nengo[tests]==3.0.0
       fail-fast: false
     env:
@@ -96,7 +96,7 @@ jobs:
             os: windows-latest
             python: "3.7"
             numpy-version: numpy==1.16.0
-            tf-version: tensorflow==2.2.0
+            tf-version: tensorflow==2.3.4
             nengo-version: nengo[tests]==3.0.0
           - script: test
             os: windows-latest

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -96,7 +96,7 @@ setup_cfg:
       - tensorflow
   coverage:
     omit_files:
-      - nengo_dl/tests/dummies.py
+      - "*/tests/dummies.py"
   flake8:
     ignore:
       - C901

--- a/.nengobones.yml
+++ b/.nengobones.yml
@@ -5,6 +5,7 @@ repo_name: nengo/nengo-dl
 description: Deep learning integration for Nengo
 copyright_start: 2015
 license: abr-free
+main_branch: main
 
 min_python: "3.7"
 

--- a/.templates/setup.py.template
+++ b/.templates/setup.py.template
@@ -49,7 +49,5 @@ install_req = [
     "jinja2>=2.10.1",
     "packaging>=20.0",
     "progressbar2>=3.39.0",
-    # fixes a bug in TF, see https://github.com/tensorflow/tensorflow/issues/56077
-    "protobuf<4.21.0rc0",
 ]
 {% endblock %}

--- a/.templates/setup.py.template
+++ b/.templates/setup.py.template
@@ -45,7 +45,7 @@ else:
 install_req = [
     "nengo>=3.0.0",
     "numpy>=1.16.0",
-    "{}>=2.2.0".format(tf_req),
+    "{}>=2.3.4".format(tf_req),
     "{}<2.11.0rc0; sys_platform == 'win32'".format(tf_req),
     "jinja2>=2.10.1",
     "packaging>=20.0",

--- a/.templates/setup.py.template
+++ b/.templates/setup.py.template
@@ -34,6 +34,7 @@ else:
         "tf-nightly-cpu",
         "tensorflow-gpu",
         "tensorflow-cpu",
+        "tensorflow-macos",
     ]:
         if d in installed_dists:
             tf_req = d

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Release history
 
 *Compatible with Nengo 3.0 - 3.2*
 
-*Compatible with TensorFlow 2.2 - 2.11*
+*Compatible with TensorFlow 2.3 - 2.11*
 
 **Added**
 
@@ -43,6 +43,10 @@ Release history
   this functionality, and it is increasingly buggy. Graph mode may still be faster for
   some models; if you need this functionality, try using a previous version of NengoDL.
   (`#229`_)
+- Dropped support for TensorFlow 2.2. The minimum supported version is now 2.3.4
+  (earlier 2.3.x versions should work as well, but TensorFlow may install an
+  incompatible ``protobuf`` version that the user will need to manually correct).
+  (`#228`_)
 
 .. _#228: https://github.com/nengo/nengo-dl/pull/228
 .. _#229: https://github.com/nengo/nengo-dl/pull/229

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,11 @@ Release history
 
 *Compatible with TensorFlow 2.2 - 2.11*
 
+**Added**
+
+- Included ``tensorflow-macos`` in the alternative tensorflow package names checked
+  during installation. (`#228`_)
+
 **Changed**
 
 - Pinned TensorFlow version to <2.11 on Windows. As of 2.11 the TensorFlow package for
@@ -39,6 +44,7 @@ Release history
   some models; if you need this functionality, try using a previous version of NengoDL.
   (`#229`_)
 
+.. _#228: https://github.com/nengo/nengo-dl/pull/228
 .. _#229: https://github.com/nengo/nengo-dl/pull/229
 
 3.5.0 (May 18, 2022)

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -4,7 +4,7 @@
 NengoDL license
 ***************
 
-Copyright (c) 2015-2022 Applied Brain Research
+Copyright (c) 2015-2023 Applied Brain Research
 
 **ABR License**
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,7 +92,7 @@ suppress_warnings = ["image.nonlocal_uri"]
 
 project = "NengoDL"
 authors = "Applied Brain Research"
-copyright = "2015-2022 Applied Brain Research"
+copyright = "2015-2023 Applied Brain Research"
 version = ".".join(nengo_dl.__version__.split(".")[:2])  # Short X.Y version
 release = nengo_dl.__version__  # Full version, with tags
 

--- a/docs/examples/spa-memory.ipynb
+++ b/docs/examples/spa-memory.ipynb
@@ -528,7 +528,6 @@
     "    }\n",
     "\n",
     "    with nengo_dl.Simulator(net, minibatch_size=minibatch_size, seed=seed) as sim:\n",
-    "\n",
     "        sim.compile(loss={output_probe: nengo_dl.losses.nan_mse})\n",
     "        print(\n",
     "            \"Test loss before:\",\n",

--- a/nengo_dl/compat.py
+++ b/nengo_dl/compat.py
@@ -71,84 +71,7 @@ class TFLogFilter:
 
 tf.get_logger().addFilter(TFLogFilter(err_on_deprecation=False))
 
-if version.parse(tf.__version__) < version.parse("2.3.0rc0"):
-
-    def _build_map(outputs):
-        """Vendored from ``tensorflow.python.keras.engine.functional._build_map`` in TF
-        2.3.0 (with a few changes noted below)."""
-        finished_nodes = set()
-        nodes_in_progress = set()
-        nodes_in_decreasing_depth = []  # nodes from inputs -> outputs.
-        layer_indices = {}  # layer -> in traversal order.
-        for output in tf.nest.flatten(outputs):
-            _build_map_helper(
-                output,
-                finished_nodes,
-                nodes_in_progress,
-                nodes_in_decreasing_depth,
-                layer_indices,
-            )
-
-        # CHANGED: add `node.layer` alias for `node.outbound_layer`
-        for node in nodes_in_decreasing_depth:
-            node.layer = node.outbound_layer
-
-        return nodes_in_decreasing_depth, layer_indices
-
-    def _build_map_helper(
-        tensor,
-        finished_nodes,
-        nodes_in_progress,
-        nodes_in_decreasing_depth,
-        layer_indices,
-    ):
-        """Recursive helper for `_build_map`."""
-        layer, node_index, _ = tensor._keras_history  # pylint: disable=protected-access
-        node = layer._inbound_nodes[node_index]  # pylint: disable=protected-access
-
-        # Don't repeat work for shared subgraphs
-        if node in finished_nodes:
-            return
-
-        # Prevent cycles.
-        if node in nodes_in_progress:  # pragma: no cover
-            raise ValueError(
-                "The tensor "
-                + str(tensor)
-                + ' at layer "'
-                + layer.name
-                + '" is part of a cycle.'
-            )
-
-        # Store the traversal order for layer sorting.
-        if layer not in layer_indices:
-            layer_indices[layer] = len(layer_indices)
-
-        # Propagate to all previous tensors connected to this node.
-        nodes_in_progress.add(node)
-        # CHANGED: `not node.is_input` to `node.inbound_layers`
-        if node.inbound_layers:
-            # CHANGED: `node.keras_inputs` to `tf.nest.flatten(node.input_tensors)`
-            # CHANGED: `tensor` to `input_tensor` (for pylint)
-            for input_tensor in tf.nest.flatten(node.input_tensors):
-                _build_map_helper(
-                    input_tensor,
-                    finished_nodes,
-                    nodes_in_progress,
-                    nodes_in_decreasing_depth,
-                    layer_indices,
-                )
-
-        finished_nodes.add(node)
-        nodes_in_progress.remove(node)
-        nodes_in_decreasing_depth.append(node)
-
-    from tensorflow.keras import Model as Functional
-    from tensorflow.python.keras.layers import (
-        BatchNormalizationV1,
-        BatchNormalizationV2,
-    )
-elif version.parse(tf.__version__) < version.parse("2.6.0rc0"):  # pragma: no cover
+if version.parse(tf.__version__) < version.parse("2.6.0rc0"):  # pragma: no cover
     from tensorflow.python.keras.engine.functional import Functional, _build_map
     from tensorflow.python.keras.layers import (
         BatchNormalizationV1,
@@ -157,26 +80,6 @@ elif version.parse(tf.__version__) < version.parse("2.6.0rc0"):  # pragma: no co
 else:
     from keras.engine.functional import Functional, _build_map
     from keras.layers import BatchNormalizationV1, BatchNormalizationV2
-
-
-if version.parse(tf.__version__) < version.parse("2.3.0rc0"):
-    from tensorflow.python.keras.engine import network
-
-    # monkeypatch to fix bug in TF2.2, see
-    # https://github.com/tensorflow/tensorflow/issues/37548
-    old_conform = network.Network._conform_to_reference_input
-
-    def _conform_to_reference_input(self, tensor, ref_input):
-        keras_history = getattr(tensor, "_keras_history", None)
-
-        tensor = old_conform(self, tensor, ref_input)
-
-        if keras_history is not None:
-            tensor._keras_history = keras_history
-
-        return tensor
-
-    network.Network._conform_to_reference_input = _conform_to_reference_input
 
 if version.parse(tf.__version__) < version.parse("2.5.0rc0"):
 

--- a/nengo_dl/simulator.py
+++ b/nengo_dl/simulator.py
@@ -2240,7 +2240,6 @@ class SimulationData(collections.abc.Mapping):
         sigs = []
         fetches = {}
         for obj, attr in obj_attrs:
-
             sig_obj, sig_attr = self._attr_map(obj, attr)
             sig = self.sim.model.sig[sig_obj][sig_attr]
             sigs.append(sig)

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -837,8 +837,6 @@ def test_profile(Simulator, mode, tmp_path, pytestconfig):
             )
 
         path = tmp_path / "profile"
-        if version.parse(tf.__version__) < version.parse("2.3.0rc0"):
-            path /= "train"
         assert path.exists()
 
 

--- a/nengo_dl/tests/test_simulator.py
+++ b/nengo_dl/tests/test_simulator.py
@@ -419,7 +419,6 @@ def test_train_no_data(Simulator):
     net, _, p = dummies.linear_net()
 
     with Simulator(net) as sim:
-
         sim.compile(
             tf.optimizers.SGD(0.1), loss={p: lambda y_true, y_pred: abs(2.0 - y_pred)}
         )
@@ -733,7 +732,6 @@ def test_tensorboard(Simulator, tmp_path):
     # check that training summaries are output properly
     n_epochs = 3
     with Simulator(net) as sim:
-
         log_dir = tmp_path / "a_run"
 
         sim.compile(

--- a/nengo_dl/utils.py
+++ b/nengo_dl/utils.py
@@ -186,7 +186,6 @@ class ProgressBar(progressbar.ProgressBar):  # pylint: disable=too-many-ancestor
     """
 
     def __init__(self, present="", past=None, max_value=1, **kwargs):
-
         self.present = present
         self.sub_bar = None
         self.finished = None

--- a/nengo_dl/version.py
+++ b/nengo_dl/version.py
@@ -22,7 +22,7 @@ version = ".".join(str(v) for v in version_info)
 if dev is not None:
     version += ".dev%d" % dev
 
-copyright = "Copyright (c) 2015-2022 Applied Brain Research"
+copyright = "Copyright (c) 2015-2023 Applied Brain Research"
 
 import warnings  # noqa: E402 pylint: disable=wrong-import-position
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ exclude_lines =
 # Patterns for files to exclude from reporting
 omit =
     */tests/test*
-    nengo_dl/tests/dummies.py
+    */tests/dummies.py
 
 [flake8]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ else:
 install_req = [
     "nengo>=3.0.0",
     "numpy>=1.16.0",
-    "{}>=2.2.0".format(tf_req),
+    "{}>=2.3.4".format(tf_req),
     "{}<2.11.0rc0; sys_platform == 'win32'".format(tf_req),
     "jinja2>=2.10.1",
     "packaging>=20.0",

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,6 @@ install_req = [
     "jinja2>=2.10.1",
     "packaging>=20.0",
     "progressbar2>=3.39.0",
-    # fixes a bug in TF, see https://github.com/tensorflow/tensorflow/issues/56077
-    "protobuf<4.21.0rc0",
 ]
 docs_req = [
     "click>=6.7",

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ else:
         "tf-nightly-cpu",
         "tensorflow-gpu",
         "tensorflow-cpu",
+        "tensorflow-macos",
     ]:
         if d in installed_dists:
             tf_req = d


### PR DESCRIPTION
Based on https://github.com/nengo/nengo-dl/pull/228, with some minor fixups (updating the source `setup.py` template, and adding a changelog entry). Plus some unrelated commits to get tests passing again due to environmental changes (e.g. new `black` release).